### PR TITLE
Fix Issue #21：Mac及Windows下创建项目出错

### DIFF
--- a/packages/app/src/components/dialog-new-research-project.tsx
+++ b/packages/app/src/components/dialog-new-research-project.tsx
@@ -260,16 +260,20 @@ export function DialogNewResearchProject(props: DialogNewResearchProjectProps) {
   async function handleCreate() {
     if (!canSubmit()) return
 
+    const projectName = name().trim()
+    const parentDir = targetDir().trim()
+    const fullPath = `${parentDir}/${projectName}`
+
     const payload = {
-      name: name().trim(),
-      targetPath: targetDir().trim(),
+      name: projectName,
+      targetPath: fullPath,
       papers: paperPaths(),
       backgroundPath: backgroundPath(),
       goalPath: goalPath(),
     }
 
     // 保存当前的目标路径，避免在异步回调中访问 signal
-    const currentTargetDir = payload.targetPath
+    const currentTargetDir = fullPath
 
     setSubmitting(true)
     setError(undefined)


### PR DESCRIPTION
修复选择已有目录时创建项目会显示出错的bug
targetPath现在会正确拼接父目录和项目名称。
更新文件：packages/app/src/components/dialog-new-research-project.tsx 