### PR TITLE
fix: add directory creation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ opencode-dev
 logs/
 *.bun-build
 tsconfig.tsbuildinfo
+start-compare.ps1

--- a/packages/app/src/components/dialog-new-research-project.tsx
+++ b/packages/app/src/components/dialog-new-research-project.tsx
@@ -11,6 +11,7 @@ import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLayout } from "@/context/layout"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { showToast } from "@opencode-ai/ui/toast"
 
 function cleanInput(value: string) {
   const first = (value ?? "").split(/\r?\n/)[0] ?? ""
@@ -50,6 +51,8 @@ function DialogPathPicker(props: PathPickerProps) {
   const sync = useGlobalSync()
   const [filter, setFilter] = createSignal("")
   const [selected, setSelected] = createSignal<Set<string>>(new Set())
+  const [newFolderName, setNewFolderName] = createSignal("")
+  const [creatingFolder, setCreatingFolder] = createSignal(false)
 
   const home = createMemo(() => props.startDir?.() || sync.data.path.home || sync.data.path.directory || "/")
   const [cwd, setCwd] = createSignal("")
@@ -71,6 +74,51 @@ function DialogPathPicker(props: PathPickerProps) {
   const enterDir = (dirPath: string) => {
     setCwd(dirPath)
     setFilter("")
+  }
+
+  async function handleCreateFolder() {
+    const name = cleanInput(newFolderName())
+    if (!name) {
+      showToast({
+        variant: "error",
+        title: "Enter a folder name first",
+      })
+      return
+    }
+
+    const next = trimTrailing(joinPath(cwd(), name))
+
+    setCreatingFolder(true)
+    try {
+      const res = await fetch(new URL("/path/mkdir", sdk.url), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ path: next }),
+      })
+
+      if (!res.ok) {
+        const error = await res.json().catch(() => undefined)
+        throw new Error(error?.message ?? "Failed to create folder")
+      }
+
+      setNewFolderName("")
+      enterDir(next)
+      showToast({
+        variant: "success",
+        title: "Folder created",
+        description: next,
+      })
+    } catch (error: unknown) {
+      showToast({
+        variant: "error",
+        title: "Failed to create folder",
+        description: error instanceof Error ? error.message : "Please try again",
+      })
+    } finally {
+      setCreatingFolder(false)
+    }
   }
 
   type ListItem = { path: string; type: "file" | "directory" }
@@ -160,6 +208,21 @@ function DialogPathPicker(props: PathPickerProps) {
         <div class="shrink-0">
           <TextField label="搜索" placeholder="输入文件名搜索" value={filter()} onChange={setFilter} autoFocus />
         </div>
+
+        <Show when={props.mode === "directories"}>
+          <div class="shrink-0 flex items-end gap-2">
+            <TextField
+              class="flex-1"
+              label="New folder"
+              placeholder="Folder name"
+              value={newFolderName()}
+              onChange={setNewFolderName}
+            />
+            <Button variant="ghost" onClick={handleCreateFolder} disabled={creatingFolder()}>
+              Create
+            </Button>
+          </div>
+        </Show>
 
         <List
           class="flex-1 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0"

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -320,6 +320,40 @@ export namespace Server {
             })
           },
         )
+        .post(
+          "/path/mkdir",
+          describeRoute({
+            summary: "Create directory",
+            description: "Create a directory on the local filesystem.",
+            operationId: "path.mkdir",
+            responses: {
+              200: {
+                description: "Created directory",
+                content: {
+                  "application/json": {
+                    schema: resolver(
+                      z.object({
+                        path: z.string(),
+                      }),
+                    ),
+                  },
+                },
+              },
+            },
+          }),
+          validator(
+            "json",
+            z.object({
+              path: z.string(),
+            }),
+          ),
+          async (c) => {
+            const body = c.req.valid("json")
+            const path = Filesystem.resolve(body.path)
+            await Filesystem.mkdir(path)
+            return c.json({ path })
+          },
+        )
         .get(
           "/vcs",
           describeRoute({

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, writeFile } from "fs/promises"
+import { chmod, mkdir as fsMkdir, readFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { lookup } from "mime-types"
 import { realpathSync } from "fs"
@@ -60,7 +60,7 @@ export namespace Filesystem {
       }
     } catch (e) {
       if (isEnoent(e)) {
-        await mkdir(dirname(p), { recursive: true })
+        await fsMkdir(dirname(p), { recursive: true })
         if (mode) {
           await writeFile(p, content, { mode })
         } else {
@@ -83,7 +83,7 @@ export namespace Filesystem {
   ): Promise<void> {
     const dir = dirname(p)
     if (!existsSync(dir)) {
-      await mkdir(dir, { recursive: true })
+      await fsMkdir(dir, { recursive: true })
     }
 
     const nodeStream = stream instanceof ReadableStream ? Readable.fromWeb(stream as any) : stream
@@ -93,6 +93,10 @@ export namespace Filesystem {
     if (mode) {
       await chmod(p, mode)
     }
+  }
+
+  export async function mkdir(p: string): Promise<void> {
+    await fsMkdir(p, { recursive: true })
   }
 
   export function mimeType(p: string): string {


### PR DESCRIPTION
## What
- Add a backend `POST /path/mkdir` endpoint for creating directories
- Add a small New folder flow inside the directory picker
- Show success/failure feedback instead of failing silently

## Why
- The previous frontend-only approach could not reliably create folders for external paths
- Moving directory creation to the backend keeps the flow predictable and easier to verify

## Test
- Manually verified `POST /path/mkdir`
- Manually verified folder creation from the picker UI