### PR TITLE
feat: frontend error reporting to backend log

### DIFF
--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -79,15 +79,25 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       staleDeltas.clear()
 
       last = Date.now()
-      batch(() => {
-        for (const event of events) {
-          if (skip && event.payload.type === "message.part.delta") {
-            const props = event.payload.properties
-            if (skip.has(deltaKey(event.directory, props.messageID, props.partID))) continue
+      try {
+        batch(() => {
+          for (const event of events) {
+            if (skip && event.payload.type === "message.part.delta") {
+              const props = event.payload.properties
+              if (skip.has(deltaKey(event.directory, props.messageID, props.partID))) continue
+            }
+            emitter.emit(event.directory, event.payload)
           }
-          emitter.emit(event.directory, event.payload)
-        }
-      })
+        })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        const stack = err instanceof Error ? err.stack : undefined
+        fetch(`${currentServer.http.url}/global/log-client`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ level: "error", message, stack, url: location.href, extra: { source: "global-sdk:flush" } }),
+        }).catch(() => {})
+      }
 
       buffer.length = 0
     }

--- a/packages/app/src/context/global-sdk.tsx
+++ b/packages/app/src/context/global-sdk.tsx
@@ -92,9 +92,12 @@ export const { use: useGlobalSDK, provider: GlobalSDKProvider } = createSimpleCo
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         const stack = err instanceof Error ? err.stack : undefined
+        const authHeader = currentServer.http.password
+          ? { Authorization: `Basic ${btoa(`${currentServer.http.username ?? "opencode"}:${currentServer.http.password}`)}` }
+          : undefined
         fetch(`${currentServer.http.url}/global/log-client`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: { "Content-Type": "application/json", ...(authHeader ?? {}) } as HeadersInit,
           body: JSON.stringify({ level: "error", message, stack, url: location.href, extra: { source: "global-sdk:flush" } }),
         }).catch(() => {})
       }

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -121,6 +121,31 @@ const defaultUrl = iife(() => {
 
 if (root instanceof HTMLElement) {
   const server: ServerConnection.Http = { type: "http", http: { url: defaultUrl } }
+
+  // Global error reporter — sends uncaught errors to backend log (best-effort)
+  const reportToServer = (level: "error" | "warn", message: string, stack?: string, extra?: Record<string, unknown>) => {
+    fetch(`${defaultUrl}/global/log-client`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ level, message, stack, url: location.href, extra }),
+    }).catch(() => {})
+  }
+
+  window.addEventListener("error", (e) => {
+    reportToServer("error", e.message || "Unknown error", e.error?.stack, {
+      filename: e.filename,
+      lineno: e.lineno,
+      colno: e.colno,
+    })
+  })
+
+  window.addEventListener("unhandledrejection", (e) => {
+    const reason = e.reason
+    const message = reason instanceof Error ? reason.message : String(reason ?? "Unhandled rejection")
+    const stack = reason instanceof Error ? reason.stack : undefined
+    reportToServer("error", message, stack)
+  })
+
   render(
     () => (
       <PlatformProvider value={platform}>

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -124,9 +124,12 @@ if (root instanceof HTMLElement) {
 
   // Global error reporter — sends uncaught errors to backend log (best-effort)
   const reportToServer = (level: "error" | "warn", message: string, stack?: string, extra?: Record<string, unknown>) => {
+    const authHeader = server.http.password
+      ? { Authorization: `Basic ${btoa(`${server.http.username ?? "opencode"}:${server.http.password}`)}` }
+      : undefined
     fetch(`${defaultUrl}/global/log-client`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...(authHeader ?? {}) } as HeadersInit,
       body: JSON.stringify({ level, message, stack, url: location.href, extra }),
     }).catch(() => {})
   }

--- a/packages/opencode/src/server/routes/global.ts
+++ b/packages/opencode/src/server/routes/global.ts
@@ -181,5 +181,43 @@ export const GlobalRoutes = lazy(() =>
         })
         return c.json(true)
       },
+    )
+    .post(
+      "/log-client",
+      describeRoute({
+        summary: "Log client-side error",
+        description: "Receive a frontend error report and write it to the server log file.",
+        operationId: "global.log.client",
+        responses: {
+          200: {
+            description: "Logged",
+            content: { "application/json": { schema: resolver(z.boolean()) } },
+          },
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          level: z.enum(["debug", "info", "warn", "error"]).default("error"),
+          message: z.string(),
+          stack: z.string().optional(),
+          url: z.string().optional(),
+          extra: z.record(z.string(), z.unknown()).optional(),
+        }),
+      ),
+      async (c) => {
+        const body = c.req.valid("json")
+        const entry = {
+          service: "client",
+          message: body.message,
+          ...(body.stack ? { stack: body.stack } : {}),
+          ...(body.url ? { url: body.url } : {}),
+          ...(body.extra ?? {}),
+        }
+        if (body.level === "error") log.error("client error", entry)
+        else if (body.level === "warn") log.warn("client warn", entry)
+        else log.info("client log", entry)
+        return c.json(true)
+      },
     ),
 )


### PR DESCRIPTION
## 功能说明

将前端未捕获错误上报到后端日志，便于在无头服务器上调试 UI 问题。

## 变更内容

### 后端
- 新增 `POST /global/log-client` 接口，接收前端错误写入 `dev.log`
- 按 level（error/warn/info）分级记录，带 `service=client` 标签便于过滤
- 支持 `OPENCODE_SERVER_PASSWORD` 认证

### 前端
- `entry.tsx`: 注册 `window.onerror` + `unhandledrejection` 全局监听
- `global-sdk.tsx`: 在 `flush()` 的 `batch()` 外加 try-catch，捕获 SolidJS 响应式系统内部错误（不会冒泡到 window.onerror）
- 两处 fetch 均附带 Basic Auth header

## 查看日志

```bash
grep "service=client" ~/.local/share/opencode/log/dev.log | tail -20
```