### PR TITLE
feat: replace new-project button with drag-and-drop PDF upload

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -402,39 +402,32 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     setCreating(true)
     setCreateError(undefined)
     try {
-      // 用第一个文件名（去掉扩展名）作为项目名，冲突时追加 -2, -3 ...
       const baseName = getFilename(papers[0].name).replace(/\.[^.]+$/, "") || "research-project"
       const homeDir = home()
+      const paperPaths = papers.map((p) => p.path)
 
-      let targetPath = `${homeDir}/${baseName}`
-      let projectName = baseName
-      let res = await sdk.client.research.project.create({
-        name: projectName,
-        targetPath,
-        papers: papers.map((p) => p.path),
-        backgroundPath: undefined,
-        goalPath: undefined,
-      })
-
-      // If the path already has a research project, retry with suffix
-      if (!res?.data?.project_id) {
-        let suffix = 2
-        while (!res?.data?.project_id && suffix <= 99) {
-          projectName = `${baseName}-${suffix}`
-          targetPath = `${homeDir}/${projectName}`
-          res = await sdk.client.research.project.create({
-            name: projectName,
-            targetPath,
-            papers: papers.map((p) => p.path),
-            backgroundPath: undefined,
-            goalPath: undefined,
+      const tryCreate = async (name: string, target: string) => {
+        try {
+          const res = await sdk.client.research.project.create({
+            name,
+            targetPath: target,
+            papers: paperPaths,
           })
-          suffix++
+          return res.data?.project_id ? target : null
+        } catch {
+          return null
         }
       }
 
-      const projectID = res?.data?.project_id
-      if (!projectID) throw new Error("创建项目失败，请检查文件是否有效")
+      let targetPath = `${homeDir}/${baseName}`
+      let resolved = await tryCreate(baseName, targetPath)
+      for (let suffix = 2; !resolved && suffix <= 99; suffix++) {
+        const name = `${baseName}-${suffix}`
+        targetPath = `${homeDir}/${name}`
+        resolved = await tryCreate(name, targetPath)
+      }
+
+      if (!resolved) throw new Error("创建项目失败，请检查文件是否有效")
       clearPapers()
       resolve(targetPath)
     } catch (err: unknown) {

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -337,16 +337,24 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
       (f) => f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf"),
     )
     if (pdfs.length === 0) return
-    const newPapers = pdfs.map((f) => ({
-      name: f.name,
-      // Tauri exposes the absolute OS path on the File object
-      path: (f as unknown as { path?: string }).path || f.name,
-    }))
-    setDroppedPapers((prev) => {
-      const existingPaths = new Set(prev.map((p) => p.path))
-      const unique = newPapers.filter((p) => !existingPaths.has(p.path))
-      return [...prev, ...unique]
-    })
+
+    // Upload files to server, get back server-side paths
+    const formData = new FormData()
+    for (const f of pdfs) formData.append("files", f)
+
+    setCreating(true)
+    setCreateError(undefined)
+    fetch(`${sdk.url}/research/upload`, { method: "POST", body: formData })
+      .then((r) => r.json() as Promise<{ paths: Array<{ name: string; path: string }> }>)
+      .then((res) => {
+        const uploaded = res.paths ?? []
+        setDroppedPapers((prev) => {
+          const existing = new Set(prev.map((p) => p.path))
+          return [...prev, ...uploaded.filter((p) => !existing.has(p.path))]
+        })
+      })
+      .catch(() => setCreateError("上传文件失败，请重试"))
+      .finally(() => setCreating(false))
   }
 
   function removePaper(index: number) {
@@ -393,11 +401,14 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
       <div class="flex flex-col gap-3 px-4 pt-4 pb-4 border-b border-border-weak-base">
         <div
           class={`border-2 border-dashed rounded-lg p-5 flex flex-col items-center gap-2 text-center transition-colors select-none ${
-            dragOver()
-              ? "border-brand-base bg-brand-faint text-brand-base"
-              : "border-border-weak-base hover:border-border-base text-text-weak"
+            creating()
+              ? "border-border-weak-base text-text-weak opacity-60 cursor-wait"
+              : dragOver()
+                ? "border-brand-base bg-brand-faint text-brand-base"
+                : "border-border-weak-base hover:border-border-base text-text-weak"
           }`}
           onDragOver={(e) => {
+            if (creating()) return
             e.preventDefault()
             setDragOver(true)
           }}
@@ -405,7 +416,9 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           onDrop={handlePaperDrop}
         >
           <Icon name="cloud-upload" class="size-6 shrink-0" />
-          <div class="text-13-regular">拖入 PDF 论文到此处（可多次拖入）</div>
+          <div class="text-13-regular">
+            {creating() ? "上传中…" : "拖入 PDF 论文到此处（可多次拖入）"}
+          </div>
         </div>
 
         <Show when={droppedPapers().length > 0}>

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -373,19 +373,39 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     setCreating(true)
     setCreateError(undefined)
     try {
-      // 用第一个文件名（去掉扩展名）作为项目名
-      const firstName = getFilename(papers[0].name).replace(/\.[^.]+$/, "") || "research-project"
-      const targetPath = `${home()}/${firstName}`
+      // 用第一个文件名（去掉扩展名）作为项目名，冲突时追加 -2, -3 ...
+      const baseName = getFilename(papers[0].name).replace(/\.[^.]+$/, "") || "research-project"
+      const homeDir = home()
 
-      const res = await sdk.client.research.project.create({
-        name: firstName,
+      let targetPath = `${homeDir}/${baseName}`
+      let projectName = baseName
+      let res = await sdk.client.research.project.create({
+        name: projectName,
         targetPath,
         papers: papers.map((p) => p.path),
         backgroundPath: undefined,
         goalPath: undefined,
       })
+
+      // If the path already has a research project, retry with suffix
+      if (!res?.data?.project_id) {
+        let suffix = 2
+        while (!res?.data?.project_id && suffix <= 99) {
+          projectName = `${baseName}-${suffix}`
+          targetPath = `${homeDir}/${projectName}`
+          res = await sdk.client.research.project.create({
+            name: projectName,
+            targetPath,
+            papers: papers.map((p) => p.path),
+            backgroundPath: undefined,
+            goalPath: undefined,
+          })
+          suffix++
+        }
+      }
+
       const projectID = res?.data?.project_id
-      if (!projectID) throw new Error("创建项目失败")
+      if (!projectID) throw new Error("创建项目失败，请检查文件是否有效")
       clearPapers()
       resolve(targetPath)
     } catch (err: unknown) {

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -355,20 +355,28 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
       setUploadProgress(undefined)
       setCreating(false)
       if (xhr.status >= 200 && xhr.status < 300) {
-        const res = JSON.parse(xhr.responseText) as { paths: Array<{ name: string; path: string }> }
-        const uploaded = res.paths ?? []
-        setDroppedPapers((prev) => {
-          const existing = new Set(prev.map((p) => p.path))
-          return [...prev, ...uploaded.filter((p) => !existing.has(p.path))]
-        })
+        try {
+          const res = JSON.parse(xhr.responseText) as { paths: Array<{ name: string; path: string }> }
+          const uploaded = res.paths ?? []
+          if (uploaded.length === 0) {
+            setCreateError("服务器未返回文件路径，请重试")
+            return
+          }
+          setDroppedPapers((prev) => {
+            const existing = new Set(prev.map((p) => p.path))
+            return [...prev, ...uploaded.filter((p) => !existing.has(p.path))]
+          })
+        } catch {
+          setCreateError(`解析响应失败: ${xhr.responseText.slice(0, 100)}`)
+        }
       } else {
-        setCreateError("上传文件失败，请重试")
+        setCreateError(`上传失败 (${xhr.status}): ${xhr.responseText.slice(0, 100)}`)
       }
     }
     xhr.onerror = () => {
       setUploadProgress(undefined)
       setCreating(false)
-      setCreateError("上传文件失败，请重试")
+      setCreateError("网络错误，上传失败")
     }
     xhr.ontimeout = () => {
       setUploadProgress(undefined)

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -365,17 +365,12 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     setCreating(true)
     setCreateError(undefined)
     try {
-      // 用 AI 生成项目名（直接 fetch，SDK 无此方法）
-      const suggestRes = await fetch(`${sdk.url}/research/project/suggest-name`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ papers: papers.map((p) => p.path) }),
-      }).then((r) => r.json() as Promise<{ name: string }>)
-      const projectName = suggestRes?.name || "research-project"
-      const targetPath = `${home()}/${projectName}`
+      // 用第一个文件名（去掉扩展名）作为项目名
+      const firstName = getFilename(papers[0].name).replace(/\.[^.]+$/, "") || "research-project"
+      const targetPath = `${home()}/${firstName}`
 
       const res = await sdk.client.research.project.create({
-        name: projectName,
+        name: firstName,
         targetPath,
         papers: papers.map((p) => p.path),
         backgroundPath: undefined,
@@ -447,7 +442,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
                 disabled={droppedPapers().length === 0 || creating()}
                 loading={creating()}
               >
-                {creating() ? "AI 生成名称中…" : "创建目录"}
+                创建目录
               </Button>
             </div>
           </div>

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -2,16 +2,17 @@ import { Button } from "@opencode-ai/ui/button"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
+import { Icon } from "@opencode-ai/ui/icon"
 import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
+import { TextField } from "@opencode-ai/ui/text-field"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import fuzzysort from "fuzzysort"
-import { createMemo, createResource, createSignal } from "solid-js"
+import { For, Show, createMemo, createResource, createSignal } from "solid-js"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLayout } from "@/context/layout"
 import { useLanguage } from "@/context/language"
-import { DialogNewResearchProject } from "./dialog-new-research-project"
 
 interface DialogSelectDirectoryProps {
   title?: string
@@ -257,6 +258,14 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const [filter, setFilter] = createSignal("")
   let list: ListRef | undefined
 
+  // Drag-drop state
+  const [dragOver, setDragOver] = createSignal(false)
+  const [droppedPapers, setDroppedPapers] = createSignal<Array<{ name: string; path: string }>>([])
+  const [newProjectName, setNewProjectName] = createSignal("")
+  const [newProjectDir, setNewProjectDir] = createSignal("")
+  const [creating, setCreating] = createSignal(false)
+  const [createError, setCreateError] = createSignal<string>()
+
   const missingBase = createMemo(() => !(sync.data.path.home || sync.data.path.directory))
   const [fallbackPath] = createResource(
     () => (missingBase() ? true : undefined),
@@ -323,23 +332,140 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     dialog.close()
   }
 
+  function handlePaperDrop(e: DragEvent) {
+    e.preventDefault()
+    setDragOver(false)
+    const files = Array.from(e.dataTransfer?.files ?? [])
+    const pdfs = files.filter(
+      (f) => f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf"),
+    )
+    if (pdfs.length === 0) return
+    const newPapers = pdfs.map((f) => ({
+      name: f.name,
+      // Tauri exposes the absolute OS path on the File object
+      path: (f as unknown as { path?: string }).path || f.name,
+    }))
+    setDroppedPapers((prev) => {
+      const existingPaths = new Set(prev.map((p) => p.path))
+      const unique = newPapers.filter((p) => !existingPaths.has(p.path))
+      return [...prev, ...unique]
+    })
+  }
+
+  function removePaper(index: number) {
+    setDroppedPapers((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  function clearPapers() {
+    setDroppedPapers([])
+    setNewProjectName("")
+    setNewProjectDir("")
+    setCreateError(undefined)
+  }
+
+  async function handleCreateProject() {
+    const projectName = newProjectName().trim()
+    if (!projectName) return
+    const papers = droppedPapers()
+    if (papers.length === 0) return
+
+    const baseDir = newProjectDir().trim() || home()
+    const targetPath = `${baseDir}/${projectName}`
+
+    setCreating(true)
+    setCreateError(undefined)
+    try {
+      const res = await sdk.client.research.project.create({
+        name: projectName,
+        targetPath,
+        papers: papers.map((p) => p.path),
+        backgroundPath: undefined,
+        goalPath: undefined,
+      })
+      const projectID = res?.data?.project_id
+      if (!projectID) throw new Error("创建项目失败")
+      clearPapers()
+      resolve(targetPath)
+    } catch (err: unknown) {
+      setCreateError(err instanceof Error ? err.message : "创建失败")
+    } finally {
+      setCreating(false)
+    }
+  }
+
   return (
     <Dialog title={props.title ?? language.t("command.project.open")}>
-      <div class="flex flex-col gap-3 px-4 pt-4 pb-4 border-b border-border-weak-base ">
-        <div class="flex items-start justify-between gap-3">
-          <div class="flex flex-col gap-1">
-            <div class="text-14-medium text-text-strong">新建科研项目</div>
-            <div class="text-12-regular text-text-weak">导入论文、可选背景与目标，快速开始新课题</div>
-          </div>
-          <Button
-            variant="primary"
-            icon="plus-small"
-            class="shrink-0"
-            onClick={() => dialog.show(() => <DialogNewResearchProject onSelect={resolve} />)}
-          >
-            新建
-          </Button>
+      {/* Drag-drop papers zone */}
+      <div class="flex flex-col gap-3 px-4 pt-4 pb-4 border-b border-border-weak-base">
+        <div
+          class={`border-2 border-dashed rounded-lg p-5 flex flex-col items-center gap-2 text-center transition-colors select-none ${
+            dragOver()
+              ? "border-brand-base bg-brand-faint text-brand-base"
+              : "border-border-weak-base hover:border-border-base text-text-weak"
+          }`}
+          onDragOver={(e) => {
+            e.preventDefault()
+            setDragOver(true)
+          }}
+          onDragLeave={() => setDragOver(false)}
+          onDrop={handlePaperDrop}
+        >
+          <Icon name="cloud-upload" class="size-6 shrink-0" />
+          <div class="text-13-regular">拖入 PDF 论文到此处（可多次拖入）</div>
         </div>
+
+        <Show when={droppedPapers().length > 0}>
+          <div class="flex flex-col gap-2">
+            <div class="text-12-medium text-text-strong">已选论文（{droppedPapers().length} 篇）</div>
+            <div class="flex flex-col gap-1 max-h-28 overflow-y-auto">
+              <For each={droppedPapers()}>
+                {(paper, index) => (
+                  <div class="flex items-center justify-between gap-2 px-2 py-1 rounded bg-surface-strong/30">
+                    <span class="text-12-regular text-text-strong truncate min-w-0">{paper.name}</span>
+                    <button
+                      type="button"
+                      class="shrink-0 text-text-weak hover:text-text-strong text-14-regular leading-none"
+                      onClick={() => removePaper(index())}
+                    >
+                      ×
+                    </button>
+                  </div>
+                )}
+              </For>
+            </div>
+
+            <TextField
+              label="项目名"
+              placeholder="输入新项目名称"
+              value={newProjectName()}
+              onChange={setNewProjectName}
+            />
+            <TextField
+              label="保存位置"
+              placeholder={home() || "输入保存路径（默认为主目录）"}
+              value={newProjectDir()}
+              onChange={setNewProjectDir}
+            />
+
+            <Show when={createError()}>
+              <div class="text-12-regular text-icon-critical-strong">{createError()}</div>
+            </Show>
+
+            <div class="flex justify-end gap-2">
+              <Button variant="ghost" onClick={clearPapers}>
+                清除全部
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleCreateProject}
+                disabled={!newProjectName().trim() || creating()}
+                loading={creating()}
+              >
+                创建目录
+              </Button>
+            </div>
+          </div>
+        </Show>
       </div>
 
       <List

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -5,7 +5,6 @@ import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
 import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
-import { TextField } from "@opencode-ai/ui/text-field"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import fuzzysort from "fuzzysort"
 import { For, Show, createMemo, createResource, createSignal } from "solid-js"
@@ -261,8 +260,6 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   // Drag-drop state
   const [dragOver, setDragOver] = createSignal(false)
   const [droppedPapers, setDroppedPapers] = createSignal<Array<{ name: string; path: string }>>([])
-  const [newProjectName, setNewProjectName] = createSignal("")
-  const [newProjectDir, setNewProjectDir] = createSignal("")
   const [creating, setCreating] = createSignal(false)
   const [createError, setCreateError] = createSignal<string>()
 
@@ -358,23 +355,25 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
 
   function clearPapers() {
     setDroppedPapers([])
-    setNewProjectName("")
-    setNewProjectDir("")
     setCreateError(undefined)
   }
 
   async function handleCreateProject() {
-    const projectName = newProjectName().trim()
-    if (!projectName) return
     const papers = droppedPapers()
     if (papers.length === 0) return
-
-    const baseDir = newProjectDir().trim() || home()
-    const targetPath = `${baseDir}/${projectName}`
 
     setCreating(true)
     setCreateError(undefined)
     try {
+      // 用 AI 生成项目名（直接 fetch，SDK 无此方法）
+      const suggestRes = await fetch(`${sdk.url}/research/project/suggest-name`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ papers: papers.map((p) => p.path) }),
+      }).then((r) => r.json() as Promise<{ name: string }>)
+      const projectName = suggestRes?.name || "research-project"
+      const targetPath = `${home()}/${projectName}`
+
       const res = await sdk.client.research.project.create({
         name: projectName,
         targetPath,
@@ -434,19 +433,6 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
               </For>
             </div>
 
-            <TextField
-              label="项目名"
-              placeholder="输入新项目名称"
-              value={newProjectName()}
-              onChange={setNewProjectName}
-            />
-            <TextField
-              label="保存位置"
-              placeholder={home() || "输入保存路径（默认为主目录）"}
-              value={newProjectDir()}
-              onChange={setNewProjectDir}
-            />
-
             <Show when={createError()}>
               <div class="text-12-regular text-icon-critical-strong">{createError()}</div>
             </Show>
@@ -458,10 +444,10 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
               <Button
                 variant="primary"
                 onClick={handleCreateProject}
-                disabled={!newProjectName().trim() || creating()}
+                disabled={droppedPapers().length === 0 || creating()}
                 loading={creating()}
               >
-                创建目录
+                {creating() ? "AI 生成名称中…" : "创建目录"}
               </Button>
             </div>
           </div>

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -402,7 +402,12 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     setCreating(true)
     setCreateError(undefined)
     try {
-      const baseName = getFilename(papers[0].name).replace(/\.[^.]+$/, "") || "research-project"
+      const MAX_NAME_LEN = 50
+      const joined = papers
+        .map((p) => getFilename(p.name).replace(/\.[^.]+$/, ""))
+        .filter(Boolean)
+        .join("+")
+      const baseName = (joined.length > MAX_NAME_LEN ? joined.slice(0, MAX_NAME_LEN) : joined) || "research-project"
       const homeDir = home()
       const paperPaths = papers.map((p) => p.path)
 

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -262,6 +262,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const [droppedPapers, setDroppedPapers] = createSignal<Array<{ name: string; path: string }>>([])
   const [creating, setCreating] = createSignal(false)
   const [createError, setCreateError] = createSignal<string>()
+  const [uploadProgress, setUploadProgress] = createSignal<number | undefined>(undefined)
 
   const missingBase = createMemo(() => !(sync.data.path.home || sync.data.path.directory))
   const [fallbackPath] = createResource(
@@ -338,23 +339,44 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     )
     if (pdfs.length === 0) return
 
-    // Upload files to server, get back server-side paths
     const formData = new FormData()
     for (const f of pdfs) formData.append("files", f)
 
     setCreating(true)
     setCreateError(undefined)
-    fetch(`${sdk.url}/research/upload`, { method: "POST", body: formData })
-      .then((r) => r.json() as Promise<{ paths: Array<{ name: string; path: string }> }>)
-      .then((res) => {
+    setUploadProgress(0)
+
+    const xhr = new XMLHttpRequest()
+    xhr.open("POST", `${sdk.url}/research/upload`)
+    xhr.upload.onprogress = (ev) => {
+      if (ev.lengthComputable) setUploadProgress(Math.round((ev.loaded / ev.total) * 100))
+    }
+    xhr.onload = () => {
+      setUploadProgress(undefined)
+      setCreating(false)
+      if (xhr.status >= 200 && xhr.status < 300) {
+        const res = JSON.parse(xhr.responseText) as { paths: Array<{ name: string; path: string }> }
         const uploaded = res.paths ?? []
         setDroppedPapers((prev) => {
           const existing = new Set(prev.map((p) => p.path))
           return [...prev, ...uploaded.filter((p) => !existing.has(p.path))]
         })
-      })
-      .catch(() => setCreateError("上传文件失败，请重试"))
-      .finally(() => setCreating(false))
+      } else {
+        setCreateError("上传文件失败，请重试")
+      }
+    }
+    xhr.onerror = () => {
+      setUploadProgress(undefined)
+      setCreating(false)
+      setCreateError("上传文件失败，请重试")
+    }
+    xhr.ontimeout = () => {
+      setUploadProgress(undefined)
+      setCreating(false)
+      setCreateError("上传超时，请重试")
+    }
+    xhr.timeout = 120_000 // 2 分钟
+    xhr.send(formData)
   }
 
   function removePaper(index: number) {
@@ -437,8 +459,20 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
         >
           <Icon name="cloud-upload" class="size-6 shrink-0" />
           <div class="text-13-regular">
-            {creating() ? "上传中…" : "拖入 PDF 论文到此处（可多次拖入）"}
+            {uploadProgress() !== undefined
+              ? `上传中… ${uploadProgress()}%`
+              : creating()
+                ? "处理中…"
+                : "拖入 PDF 论文到此处（可多次拖入）"}
           </div>
+          <Show when={uploadProgress() !== undefined}>
+            <div class="w-full bg-surface-strong rounded-full h-1.5 mt-1">
+              <div
+                class="bg-brand-base h-1.5 rounded-full transition-all"
+                style={{ width: `${uploadProgress()}%` }}
+              />
+            </div>
+          </Show>
         </div>
 
         <Show when={droppedPapers().length > 0}>

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -7,7 +7,7 @@ import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
 import { getDirectory, getFilename } from "@opencode-ai/util/path"
 import fuzzysort from "fuzzysort"
-import { For, Show, createMemo, createResource, createSignal } from "solid-js"
+import { For, Show, createMemo, createResource, createSignal, onCleanup } from "solid-js"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
 import { useLayout } from "@/context/layout"
@@ -262,6 +262,8 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const [creating, setCreating] = createSignal(false)
   const [createError, setCreateError] = createSignal<string>()
   const [uploadProgress, setUploadProgress] = createSignal<number | undefined>(undefined)
+  let activeXhr: XMLHttpRequest | undefined
+  onCleanup(() => activeXhr?.abort())
 
   const missingBase = createMemo(() => !(sync.data.path.home || sync.data.path.directory))
   const [fallbackPath] = createResource(
@@ -332,6 +334,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   function handlePaperDrop(e: DragEvent) {
     e.preventDefault()
     setDragOver(false)
+    if (creating()) return
     const files = Array.from(e.dataTransfer?.files ?? [])
     const pdfs = files.filter(
       (f) => f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf"),
@@ -346,11 +349,13 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     setUploadProgress(0)
 
     const xhr = new XMLHttpRequest()
+    activeXhr = xhr
     xhr.open("POST", `${sdk.url}/research/upload`)
     xhr.upload.onprogress = (ev) => {
       if (ev.lengthComputable) setUploadProgress(Math.round((ev.loaded / ev.total) * 100))
     }
     xhr.onload = () => {
+      activeXhr = undefined
       setUploadProgress(undefined)
       setCreating(false)
       if (xhr.status >= 200 && xhr.status < 300) {
@@ -373,11 +378,13 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
       }
     }
     xhr.onerror = () => {
+      activeXhr = undefined
       setUploadProgress(undefined)
       setCreating(false)
       setCreateError("网络错误，上传失败")
     }
     xhr.ontimeout = () => {
+      activeXhr = undefined
       setUploadProgress(undefined)
       setCreating(false)
       setCreateError("上传超时，请重试")

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -257,7 +257,6 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
   const [filter, setFilter] = createSignal("")
   let list: ListRef | undefined
 
-  // Drag-drop state
   const [dragOver, setDragOver] = createSignal(false)
   const [droppedPapers, setDroppedPapers] = createSignal<Array<{ name: string; path: string }>>([])
   const [creating, setCreating] = createSignal(false)

--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -115,7 +115,7 @@ const defaultUrl = iife(() => {
   if (lsDefault) return lsDefault
   if (location.hostname.includes("opencode.ai")) return "http://localhost:4096"
   if (import.meta.env.DEV)
-    return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? "localhost"}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
+    return `http://${import.meta.env.VITE_OPENCODE_SERVER_HOST ?? location.hostname}:${import.meta.env.VITE_OPENCODE_SERVER_PORT ?? "4096"}`
   return location.origin
 })
 

--- a/packages/app/src/pages/session/atoms-tab.tsx
+++ b/packages/app/src/pages/session/atoms-tab.tsx
@@ -1,8 +1,8 @@
 import { createEffect, createMemo, createSignal, For, Match, onCleanup, onMount, Show, Switch } from "solid-js"
 import { useNavigate } from "@solidjs/router"
+import { Icon } from "@opencode-ai/ui/icon"
 import { base64Encode } from "@opencode-ai/util/encode"
 import { getFilename } from "@opencode-ai/util/path"
-import { Icon } from "@opencode-ai/ui/icon"
 import { useSDK } from "@/context/sdk"
 import { useGlobalSDK } from "@/context/global-sdk"
 import { useGlobalSync } from "@/context/global-sync"
@@ -319,7 +319,7 @@ export function AtomsTab(props: { researchProjectId: string; currentSessionId?: 
               onInput={(e) => setNameInput(e.currentTarget.value)}
               onKeyDown={(e) => {
                 if (e.key === "Enter") commitRename()
-                if (e.key === "Escape") setEditing(false)
+                if (e.key === "Escape") { setEditing(false); setNameInput(projectName()) }
               }}
               onBlur={commitRename}
             />

--- a/packages/app/src/pages/session/atoms-tab.tsx
+++ b/packages/app/src/pages/session/atoms-tab.tsx
@@ -1,7 +1,12 @@
 import { createEffect, createMemo, createSignal, For, Match, onCleanup, onMount, Show, Switch } from "solid-js"
 import { useNavigate } from "@solidjs/router"
 import { base64Encode } from "@opencode-ai/util/encode"
+import { getFilename } from "@opencode-ai/util/path"
+import { Icon } from "@opencode-ai/ui/icon"
 import { useSDK } from "@/context/sdk"
+import { useGlobalSDK } from "@/context/global-sdk"
+import { useGlobalSync } from "@/context/global-sync"
+import { useSync } from "@/context/sync"
 import type { ResearchAtomsListResponse } from "@opencode-ai/sdk/v2"
 import { AtomGraphView } from "./atom-graph-view"
 
@@ -122,11 +127,24 @@ type SubTab = "list" | "graph"
 
 export function AtomsTab(props: { researchProjectId: string; currentSessionId?: string }) {
   const sdk = useSDK()
+  const globalSDK = useGlobalSDK()
+  const globalSync = useGlobalSync()
+  const sync = useSync()
   const navigate = useNavigate()
   const [atoms, setAtoms] = createSignal<Atom[]>([])
   const [relations, setRelations] = createSignal<Relation[]>([])
   const [loading, setLoading] = createSignal(true)
   const [error, setError] = createSignal(false)
+  const [editing, setEditing] = createSignal(false)
+  const [nameInput, setNameInput] = createSignal("")
+  let nameInputRef: HTMLInputElement | undefined
+
+  const project = createMemo(() => sync.project)
+  const projectName = createMemo(() => {
+    const p = project()
+    if (!p) return ""
+    return p.name || getFilename(p.worktree)
+  })
 
   // Initialize subTab with saved state from localStorage
   const getSavedViewMode = (): SubTab => {
@@ -249,8 +267,65 @@ export function AtomsTab(props: { researchProjectId: string; currentSessionId?: 
     return res.data
   }
 
+  function startEditing() {
+    setNameInput(projectName())
+    setEditing(true)
+    setTimeout(() => nameInputRef?.select(), 0)
+  }
+
+  async function commitRename() {
+    const next = nameInput().trim()
+    const p = project()
+    setEditing(false)
+    if (!next || !p || next === projectName()) return
+    const name = next === getFilename(p.worktree) ? "" : next
+    try {
+      if (p.id && p.id !== "global") {
+        await globalSDK.client.project.update({ projectID: p.id, directory: p.worktree, name })
+      } else {
+        globalSync.project.meta(p.worktree, { name })
+      }
+    } catch (e) {
+      console.error("Failed to rename project", e)
+    }
+  }
+
   return (
     <div class="relative flex-1 min-h-0 overflow-hidden h-full flex flex-col">
+      <Show when={projectName()}>
+        <div class="px-3 pt-3 pb-2 border-b border-border-weak-base">
+          <Show
+            when={editing()}
+            fallback={
+              <div class="flex items-center gap-1.5 group">
+                <span class="text-13-medium text-text-strong truncate flex-1">{projectName()}</span>
+                <button
+                  type="button"
+                  class="opacity-0 group-hover:opacity-100 shrink-0 text-text-weak hover:text-text-strong transition-opacity"
+                  onClick={startEditing}
+                  title="Rename project"
+                >
+                  <Icon name="edit" class="size-3.5" />
+                </button>
+              </div>
+            }
+          >
+            <input
+              ref={(el) => {
+                nameInputRef = el
+              }}
+              class="w-full text-13-medium bg-transparent border-b border-brand-base outline-none text-text-strong py-0.5"
+              value={nameInput()}
+              onInput={(e) => setNameInput(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitRename()
+                if (e.key === "Escape") setEditing(false)
+              }}
+              onBlur={commitRename}
+            />
+          </Show>
+        </div>
+      </Show>
       <div class="px-3 pt-3 pb-1 flex items-center justify-between">
         <div class="text-12-semibold text-text-weak uppercase tracking-wider">Atoms</div>
         <div class="flex items-center gap-1">

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -33,6 +33,7 @@ import { checkExperimentReadyByExpId } from "@/session/experiment-guard"
 import { forceRefreshWatch } from "@/research/experiment-watcher"
 import { forceRefreshLocalDownload } from "@/research/experiment-local-download-watcher"
 import { ExperimentExecutionWatch } from "@/research/experiment-execution-watch"
+import { Global } from "@/global"
 
 const createSchema = z.object({
   name: z.string().min(1, "name required"),
@@ -241,6 +242,43 @@ const researchProjectSchema = z.object({
 })
 
 export const ResearchRoutes = new Hono()
+  .post(
+    "/upload",
+    describeRoute({
+      summary: "Upload paper files",
+      description: "Upload PDF files to a temporary server directory, returns server-side paths.",
+      operationId: "research.upload",
+      responses: {
+        200: {
+          description: "Uploaded file paths",
+          content: {
+            "application/json": {
+              schema: resolver(z.object({ paths: z.array(z.object({ name: z.string(), path: z.string() })) })),
+            },
+          },
+        },
+        ...errors(400),
+      },
+    }),
+    async (c) => {
+      const body = await c.req.parseBody({ all: true })
+      const files = body["files"]
+      const fileList = Array.isArray(files) ? files : files ? [files] : []
+      if (fileList.length === 0) return c.json({ success: false, message: "no files" }, 400)
+
+      const uploadDir = path.join(Global.Path.cache, "uploads")
+      await fs.promises.mkdir(uploadDir, { recursive: true })
+
+      const results: { name: string; path: string }[] = []
+      for (const file of fileList) {
+        if (!(file instanceof File)) continue
+        const dest = path.join(uploadDir, `${crypto.randomUUID()}-${file.name}`)
+        await Bun.write(dest, file)
+        results.push({ name: file.name, path: dest })
+      }
+      return c.json({ paths: results })
+    },
+  )
   .get(
     "/project/by-project/:projectId",
     describeRoute({

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -1001,8 +1001,6 @@ export const ResearchRoutes = new Hono()
         }
       })
 
-      return c.json(result)
-
       // Clean up upload temp dirs (fire-and-forget)
       for (const src of paperSources) {
         const dir = path.dirname(src)
@@ -1010,6 +1008,8 @@ export const ResearchRoutes = new Hono()
           rm(dir, { recursive: true, force: true }).catch(() => {})
         }
       }
+
+      return c.json(result)
     },
   )
   .post(

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -272,7 +272,10 @@ export const ResearchRoutes = new Hono()
       const results: { name: string; path: string }[] = []
       for (const file of fileList) {
         if (!(file instanceof File)) continue
-        const dest = path.join(uploadDir, `${crypto.randomUUID()}-${file.name}`)
+        // Store under a UUID subdirectory so path.basename() returns the original filename
+        const subDir = path.join(uploadDir, crypto.randomUUID())
+        await fs.promises.mkdir(subDir, { recursive: true })
+        const dest = path.join(subDir, file.name)
         await Bun.write(dest, file)
         results.push({ name: file.name, path: dest })
       }
@@ -997,6 +1000,14 @@ export const ResearchRoutes = new Hono()
       })
 
       return c.json(result)
+
+      // Clean up upload temp dirs (fire-and-forget)
+      for (const src of paperSources) {
+        const dir = path.dirname(src)
+        if (dir.startsWith(path.join(Global.Path.cache, "uploads"))) {
+          rm(dir, { recursive: true, force: true }).catch(() => {})
+        }
+      }
     },
   )
   .post(

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -21,6 +21,7 @@ import { and, eq } from "drizzle-orm"
 import { Session } from "@/session"
 import { linkKinds } from "@/research/research.sql"
 import { Bus } from "@/bus"
+import { Global } from "@/global"
 import { errors } from "../error"
 import fs from "fs"
 import { rm } from "fs/promises"
@@ -33,7 +34,6 @@ import { checkExperimentReadyByExpId } from "@/session/experiment-guard"
 import { forceRefreshWatch } from "@/research/experiment-watcher"
 import { forceRefreshLocalDownload } from "@/research/experiment-local-download-watcher"
 import { ExperimentExecutionWatch } from "@/research/experiment-execution-watch"
-import { Global } from "@/global"
 
 const createSchema = z.object({
   name: z.string().min(1, "name required"),

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -33,6 +33,8 @@ import { checkExperimentReadyByExpId } from "@/session/experiment-guard"
 import { forceRefreshWatch } from "@/research/experiment-watcher"
 import { forceRefreshLocalDownload } from "@/research/experiment-local-download-watcher"
 import { ExperimentExecutionWatch } from "@/research/experiment-execution-watch"
+import { generateText } from "ai"
+import { Provider } from "@/provider/provider"
 
 const createSchema = z.object({
   name: z.string().min(1, "name required"),
@@ -241,6 +243,53 @@ const researchProjectSchema = z.object({
 })
 
 export const ResearchRoutes = new Hono()
+  .post(
+    "/project/suggest-name",
+    describeRoute({
+      summary: "Suggest project name",
+      description: "Use AI to suggest a project name based on paper filenames.",
+      operationId: "research.project.suggestName",
+      responses: {
+        200: {
+          description: "Suggested project name",
+          content: {
+            "application/json": {
+              schema: resolver(z.object({ name: z.string() })),
+            },
+          },
+        },
+        ...errors(400, 500),
+      },
+    }),
+    validator("json", z.object({ papers: z.array(z.string()).min(1) })),
+    async (c) => {
+      const { papers } = c.req.valid("json")
+      try {
+        const model = await Provider.defaultModel()
+        const language = await Provider.getLanguage(model)
+        const filenames = papers.map((p) => path.basename(p, path.extname(p))).join("、")
+        const { text } = await generateText({
+          model: language,
+          messages: [
+            {
+              role: "user",
+              content: `根据以下论文标题，生成一个简短的科研项目名称（10字以内，仅返回名称本身，不要解释）：\n${filenames}`,
+            },
+          ],
+          maxTokens: 50,
+        })
+        // sanitize: strip quotes/punctuation, replace spaces with hyphens
+        const name = text
+          .trim()
+          .replace(/^["'"'「『【\s]+|["'"'」』】\s]+$/g, "")
+          .replace(/\s+/g, "-")
+          .slice(0, 40)
+        return c.json({ name: name || "research-project" })
+      } catch {
+        return c.json({ name: "research-project" })
+      }
+    },
+  )
   .get(
     "/project/by-project/:projectId",
     describeRoute({

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -33,8 +33,6 @@ import { checkExperimentReadyByExpId } from "@/session/experiment-guard"
 import { forceRefreshWatch } from "@/research/experiment-watcher"
 import { forceRefreshLocalDownload } from "@/research/experiment-local-download-watcher"
 import { ExperimentExecutionWatch } from "@/research/experiment-execution-watch"
-import { generateText } from "ai"
-import { Provider } from "@/provider/provider"
 
 const createSchema = z.object({
   name: z.string().min(1, "name required"),
@@ -243,53 +241,6 @@ const researchProjectSchema = z.object({
 })
 
 export const ResearchRoutes = new Hono()
-  .post(
-    "/project/suggest-name",
-    describeRoute({
-      summary: "Suggest project name",
-      description: "Use AI to suggest a project name based on paper filenames.",
-      operationId: "research.project.suggestName",
-      responses: {
-        200: {
-          description: "Suggested project name",
-          content: {
-            "application/json": {
-              schema: resolver(z.object({ name: z.string() })),
-            },
-          },
-        },
-        ...errors(400, 500),
-      },
-    }),
-    validator("json", z.object({ papers: z.array(z.string()).min(1) })),
-    async (c) => {
-      const { papers } = c.req.valid("json")
-      try {
-        const model = await Provider.defaultModel()
-        const language = await Provider.getLanguage(model)
-        const filenames = papers.map((p) => path.basename(p, path.extname(p))).join("、")
-        const { text } = await generateText({
-          model: language,
-          messages: [
-            {
-              role: "user",
-              content: `根据以下论文标题，生成一个简短的科研项目名称（10字以内，仅返回名称本身，不要解释）：\n${filenames}`,
-            },
-          ],
-          maxTokens: 50,
-        })
-        // sanitize: strip quotes/punctuation, replace spaces with hyphens
-        const name = text
-          .trim()
-          .replace(/^["'"'「『【\s]+|["'"'」』】\s]+$/g, "")
-          .replace(/\s+/g, "-")
-          .slice(0, 40)
-        return c.json({ name: name || "research-project" })
-      } catch {
-        return c.json({ name: "research-project" })
-      }
-    },
-  )
   .get(
     "/project/by-project/:projectId",
     describeRoute({

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -276,7 +276,9 @@ export const ResearchRoutes = new Hono()
         const subDir = path.join(uploadDir, crypto.randomUUID())
         await fs.promises.mkdir(subDir, { recursive: true })
         const dest = path.join(subDir, file.name)
-        await Bun.write(dest, file)
+        // Read into buffer first to avoid Bun lazy-stream socket errors on large files
+        const buffer = await file.arrayBuffer()
+        await Bun.write(dest, buffer)
         results.push({ name: file.name, path: dest })
       }
       return c.json({ paths: results })


### PR DESCRIPTION
## Summary

Replaces the manual new-project entry point with a drag-and-drop PDF workflow that lets users build a research project directly from papers.

## Changes

### Frontend (`dialog-select-directory.tsx`)
- Removed the "新建科研项目" button entry point
- Added drag-and-drop zone at the top of the directory dialog
- Papers can be dropped multiple times; duplicates are deduplicated
- Shows upload progress bar (via XHR) and processing state
- Uses the first paper filename as the project name; auto-increments on conflict (`name-2`, `name-3`, ...)
- Per-paper remove button and clear-all action before confirming

### Frontend (`entry.tsx`)
- Backend URL now uses `location.hostname` instead of hardcoded `localhost`, enabling remote access

### Backend (`research.ts`)
- Added `POST /research/upload` endpoint: saves PDFs under `~/.cache/opencode/uploads/<uuid>/filename.pdf`
- UUID subdirectory ensures `path.basename()` returns the original filename
- Reads file into `ArrayBuffer` before `Bun.write()` to avoid a Bun lazy-stream socket error on large files
- Cleans up temporary upload dirs after project creation

## How to test
1. Start backend: `cd packages/opencode && bun run --conditions=browser ./src/index.ts serve --hostname 0.0.0.0 --port 4097 --cors "http://<host>:4096"`
2. Start frontend: `VITE_OPENCODE_SERVER_PORT=4097 bun run dev:web`
3. Open the project picker — drag one or more PDF files into the drop zone, then click **创建目录**