### PR TITLE
 fix: reload Instance cache after research project creation

### DIFF
--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -897,6 +897,13 @@ export const ResearchRoutes = new Hono()
         project = await Project.fromDirectory(target)
         if (project.project.id === "global") throw new Error("failed to resolve initialized project id")
 
+        // Invalidate Instance cache so subsequent requests return the correct project ID
+        await Instance.reload({
+          directory: target,
+          worktree: target,
+          project: project.project,
+        }).catch(() => {})
+
         const existing = Database.use((db) =>
           db
             .select({ research_project_id: ResearchProjectTable.research_project_id })


### PR DESCRIPTION
  研究项目创建后 Instance 内存缓存未更新，导致前端通过
  project.current() 拿到旧的 project ID，无法关联到新创建的
  研究项目记录。重启后端后缓存重建才恢复正常。

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
