### PR TITLE
 fix(atom-detail): sync session id before toggling chat

### DIFF
--- a/packages/app/src/pages/session/atom-detail-panel.tsx
+++ b/packages/app/src/pages/session/atom-detail-panel.tsx
@@ -335,7 +335,13 @@ export function AtomDetailPanel(props: {
             <Show when={atomSessionId()}>
               <Show when={props.onToggleChat}>
                 <button
-                  onClick={props.onToggleChat}
+                  onClick={() => {
+                    // Sync session ID to parent synchronously before toggling chat.
+                    // On remount, the notify-parent effect may not have flushed yet,
+                    // which leaves parent's atomSessionId null and breaks the chat Show condition.
+                    props.onAtomSessionId?.(atomSessionId())
+                    props.onToggleChat?.()
+                  }}
                   title={props.chatOpen ? "Close chat panel" : "Open chat panel"}
                   class="flex items-center gap-1 px-2 py-0.5 rounded border text-[11px] cursor-pointer shrink-0 whitespace-nowrap transition-colors"
                   classList={{

--- a/packages/app/src/pages/session/exp-detail-panel.tsx
+++ b/packages/app/src/pages/session/exp-detail-panel.tsx
@@ -205,7 +205,13 @@ export function ExpDetailPanel(props: {
             <Show when={expSessionId()}>
               <Show when={props.onToggleChat}>
                 <button
-                  onClick={props.onToggleChat}
+                  onClick={() => {
+                    // Sync session ID to parent synchronously before toggling chat.
+                    // On remount, the notify-parent effect may not have flushed yet,
+                    // which leaves parent's expSessionId null and breaks the chat Show condition.
+                    props.onExpSessionId?.(expSessionId())
+                    props.onToggleChat?.()
+                  }}
                   title={props.chatOpen ? "Close chat panel" : "Open chat panel"}
                   class="flex items-center gap-1 px-2 py-0.5 rounded border text-[11px] cursor-pointer shrink-0 whitespace-nowrap transition-colors"
                   classList={{


### PR DESCRIPTION
  Remount-after-close left parent's sessionId null at click time because
  the notify-parent createEffect hadn't flushed yet, so the chat panel's
  `chatOpen && sessionId` Show condition failed. Push the id to parent
  synchronously in the Chat button onClick so both updates land in the
  same batch. Applies to both atom and experiment detail panels.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
