### PR TITLE
feat(experiment): add Atom-controlled agent lifecycle

### DIFF
--- a/packages/app/src/components/collab/collab-agent-tree.tsx
+++ b/packages/app/src/components/collab/collab-agent-tree.tsx
@@ -10,9 +10,11 @@ type Props = {
 }
 
 const STATUS_COLOR: Record<string, string> = {
+  idle: "var(--sl-color-text-secondary, #888)",
   pending: "var(--sl-color-text-secondary, #888)",
   running: "var(--sl-color-green, #2ea043)",
   blocked_on_children: "var(--sl-color-yellow, #d4a017)",
+  waiting_interaction: "var(--sl-color-yellow, #d4a017)",
   completed: "var(--sl-color-blue, #3b82f6)",
   failed: "var(--sl-color-red, #da3633)",
   canceled: "var(--sl-color-gray, #6b7280)",

--- a/packages/app/src/components/collab/collab-waiting-banner.tsx
+++ b/packages/app/src/components/collab/collab-waiting-banner.tsx
@@ -9,9 +9,11 @@ type Props = {
 }
 
 const STATUS_COLOR: Record<string, string> = {
+  idle: "#888",
   pending: "#888",
   running: "#3b82f6",
   blocked_on_children: "#d4a017",
+  waiting_interaction: "#d4a017",
   completed: "#2ea043",
   failed: "#da3633",
   canceled: "#6b7280",

--- a/packages/app/src/context/collab-peers.tsx
+++ b/packages/app/src/context/collab-peers.tsx
@@ -25,10 +25,14 @@ export function CollabPeersProvider(props: { children: JSX.Element }) {
   const sdk = useGlobalSDK()
   const [store, setStore] = createStore<Record<string, DirectoryState>>({})
   const hydrating = new Set<string>()
+  const stale = new Set<string>()
   const subscribed = new Map<string, () => void>()
 
   async function refresh(directory: string) {
-    if (hydrating.has(directory)) return
+    if (hydrating.has(directory)) {
+      stale.add(directory)
+      return
+    }
     hydrating.add(directory)
     try {
       const res = await sdk.client.collab.peerSessions.list({ directory })
@@ -39,6 +43,7 @@ export function CollabPeersProvider(props: { children: JSX.Element }) {
       setStore(directory, (prev) => ({ ids: prev?.ids ?? [], loaded: true }))
     } finally {
       hydrating.delete(directory)
+      if (stale.delete(directory)) void refresh(directory)
     }
   }
 
@@ -46,14 +51,7 @@ export function CollabPeersProvider(props: { children: JSX.Element }) {
     if (subscribed.has(directory)) return
     const off = sdk.event.on(directory, (e) => {
       if (e.type !== "collab.agent.created") return
-      const info = e.properties.info as { session_id: string; parent_agent_id: string | null }
-      if (!info?.session_id || !info.parent_agent_id) return
-      const existing = store[directory]?.ids ?? []
-      if (existing.includes(info.session_id)) return
-      setStore(directory, (prev) => ({
-        ids: prev ? [...prev.ids, info.session_id] : [info.session_id],
-        loaded: prev?.loaded ?? true,
-      }))
+      void refresh(directory)
     })
     subscribed.set(directory, off)
   }
@@ -61,6 +59,7 @@ export function CollabPeersProvider(props: { children: JSX.Element }) {
   onCleanup(() => {
     for (const off of subscribed.values()) off()
     subscribed.clear()
+    stale.clear()
   })
 
   const value: CollabPeersValue = {

--- a/packages/app/src/context/global-sync.tsx
+++ b/packages/app/src/context/global-sync.tsx
@@ -30,6 +30,7 @@ import { bootstrapDirectory, bootstrapGlobal } from "./global-sync/bootstrap"
 import { createChildStoreManager } from "./global-sync/child-store"
 import { applyDirectoryEvent, applyGlobalEvent, cleanupDroppedSessionCaches } from "./global-sync/event-reducer"
 import { createRefreshQueue } from "./global-sync/queue"
+import { routeSessionEvent, sessionEventID } from "./global-sync/session-event-routing"
 import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
 import { trimSessions } from "./global-sync/session-trim"
 import type { ProjectMeta } from "./global-sync/types"
@@ -64,6 +65,7 @@ function createGlobalSync() {
   const booting = new Map<string, Promise<void>>()
   const sessionLoads = new Map<string, Promise<void>>()
   const sessionMeta = new Map<string, { limit: number }>()
+  const eventDirectories = new Map<string, string>()
 
   const [projectCache, setProjectCache, projectInit] = persisted(
     Persist.global("globalSync.project", ["globalSync.project.v1"]),
@@ -180,6 +182,9 @@ function createGlobalSync() {
       queue.clear(directory)
       sessionMeta.delete(directory)
       sdkCache.delete(directory)
+      for (const [sessionID, target] of eventDirectories) {
+        if (target === directory) eventDirectories.delete(sessionID)
+      }
     },
   })
 
@@ -310,25 +315,38 @@ function createGlobalSync() {
       return
     }
 
-    const existing = children.children[directory]
+    const sessionID = sessionEventID(event)
+    const cached = sessionID ? eventDirectories.get(sessionID) : undefined
+    if (sessionID && cached && !children.children[cached]) eventDirectories.delete(sessionID)
+    const routed = routeSessionEvent({
+      event,
+      directory,
+      directories: Object.keys(children.children),
+      owns: (target, sessionID) =>
+        children.children[target]?.[0].session.some((session) => session.id === sessionID) ?? false,
+      cached: cached && children.children[cached] ? cached : undefined,
+    })
+    if (routed.sessionID) eventDirectories.set(routed.sessionID, routed.directory)
+    const existing = children.children[routed.directory]
     if (!existing) return
-    children.mark(directory)
+    children.mark(routed.directory)
     const [store, setStore] = existing
     applyDirectoryEvent({
       event,
-      directory,
+      directory: routed.directory,
       store,
       setStore,
       push: queue.push,
       setSessionTodo,
       setSessionWorkflow,
-      vcsCache: children.vcsCache.get(directory),
+      vcsCache: children.vcsCache.get(routed.directory),
       loadLsp: () => {
-        sdkFor(directory)
+        sdkFor(routed.directory)
           .lsp.status()
           .then((x) => setStore("lsp", x.data ?? []))
       },
     })
+    if (event.type === "session.deleted") eventDirectories.delete(event.properties.info.id)
   })
 
   onCleanup(unsub)

--- a/packages/app/src/context/global-sync/session-event-routing.test.ts
+++ b/packages/app/src/context/global-sync/session-event-routing.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+import type { Event } from "@opencode-ai/sdk/v2/client"
+
+import { routeSessionEvent } from "./session-event-routing"
+
+const directories = ["/workspace/a", "/workspace/b"]
+const owns = (directory: string, sessionID: string) => directory === "/workspace/a" && sessionID === "session-1"
+
+describe("routeSessionEvent", () => {
+  test("routes a mislabelled message event to the loaded session directory", () => {
+    const event = {
+      type: "message.updated",
+      properties: { info: { id: "message-1", sessionID: "session-1", role: "user" } },
+    } as Event
+
+    expect(routeSessionEvent({ event, directory: "/workspace/b", directories, owns })).toEqual({
+      directory: "/workspace/a",
+      sessionID: "session-1",
+    })
+  })
+
+  test("uses a cached directory for streamed part events", () => {
+    const event = {
+      type: "message.part.delta",
+      properties: {
+        sessionID: "session-1",
+        messageID: "message-1",
+        partID: "part-1",
+        field: "text",
+        delta: "done",
+      },
+    } as Event
+
+    expect(
+      routeSessionEvent({
+        event,
+        directory: "/workspace/b",
+        cached: "/workspace/a",
+        directories,
+        owns,
+      }),
+    ).toEqual({ directory: "/workspace/a", sessionID: "session-1" })
+  })
+
+  test("uses the authoritative directory from session events", () => {
+    const event = {
+      type: "session.updated",
+      properties: { info: { id: "session-1", directory: "/workspace/a" } },
+    } as Event
+
+    expect(routeSessionEvent({ event, directory: "/workspace/b", directories, owns })).toEqual({
+      directory: "/workspace/a",
+      sessionID: "session-1",
+    })
+  })
+
+  test("keeps the completion card and assistant stream in the same session store", () => {
+    const events = [
+      {
+        type: "message.updated",
+        properties: { info: { id: "message-user", sessionID: "session-1", role: "user" } },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "part-terminal",
+            messageID: "message-user",
+            sessionID: "session-1",
+            type: "collab_return",
+            kind: "remote_task_terminal",
+          },
+        },
+      },
+      {
+        type: "message.updated",
+        properties: {
+          info: { id: "message-assistant", sessionID: "session-1", parentID: "message-user", role: "assistant" },
+        },
+      },
+      {
+        type: "message.part.delta",
+        properties: {
+          sessionID: "session-1",
+          messageID: "message-assistant",
+          partID: "part-text",
+          field: "text",
+          delta: "Task finished.",
+        },
+      },
+    ] as Event[]
+
+    let cached: string | undefined
+    const routed = events.map((event) => {
+      const result = routeSessionEvent({ event, directory: "/workspace/b", cached, directories, owns })
+      cached = result.directory
+      return result.directory
+    })
+    expect(routed).toEqual(["/workspace/a", "/workspace/a", "/workspace/a", "/workspace/a"])
+  })
+
+  test("leaves non-session events in their envelope directory", () => {
+    const event = { type: "server.heartbeat", properties: {} } as unknown as Event
+    expect(routeSessionEvent({ event, directory: "/workspace/b", directories, owns })).toEqual({
+      directory: "/workspace/b",
+    })
+  })
+})

--- a/packages/app/src/context/global-sync/session-event-routing.ts
+++ b/packages/app/src/context/global-sync/session-event-routing.ts
@@ -1,0 +1,50 @@
+import type { Event } from "@opencode-ai/sdk/v2/client"
+
+function info(event: Event) {
+  if (event.type !== "session.created" && event.type !== "session.updated" && event.type !== "session.deleted") return
+  return (event.properties as { info: { id: string; directory: string } }).info
+}
+
+export function sessionEventID(event: Event) {
+  const session = info(event)
+  if (session) return session.id
+  switch (event.type) {
+    case "session.status":
+    case "session.diff":
+    case "todo.updated":
+    case "workflow.updated":
+    case "message.removed":
+    case "message.part.removed":
+    case "message.part.delta":
+      return (event.properties as { sessionID: string }).sessionID
+    case "message.updated":
+      return (event.properties as { info: { sessionID: string } }).info.sessionID
+    case "message.part.updated":
+      return (event.properties as { part: { sessionID: string } }).part.sessionID
+  }
+}
+
+export function routeSessionEvent(input: {
+  event: Event
+  directory: string
+  cached?: string
+  directories: Iterable<string>
+  owns: (directory: string, sessionID: string) => boolean
+}) {
+  const directories = new Set(input.directories)
+  const session = info(input.event)
+  if (session?.directory && directories.has(session.directory)) {
+    return { directory: session.directory, sessionID: session.id }
+  }
+
+  const sessionID = sessionEventID(input.event)
+  if (!sessionID) return { directory: input.directory }
+  if (input.cached && directories.has(input.cached)) return { directory: input.cached, sessionID }
+  if (directories.has(input.directory) && input.owns(input.directory, sessionID)) {
+    return { directory: input.directory, sessionID }
+  }
+  for (const directory of directories) {
+    if (input.owns(directory, sessionID)) return { directory, sessionID }
+  }
+  return { directory: input.directory, sessionID }
+}

--- a/packages/app/src/pages/session/composer/session-collab-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-collab-dock.tsx
@@ -31,9 +31,10 @@ const STATUS_ORDER: Record<string, number> = {
   pending: 1,
   waiting_interaction: 2,
   blocked_on_children: 3,
-  completed: 4,
-  canceled: 5,
-  failed: 6,
+  idle: 4,
+  completed: 5,
+  canceled: 6,
+  failed: 7,
 }
 
 function badge(kind: Badge, labels: { running: string; blocked: string; pending: string }) {

--- a/packages/opencode/migration/20260726102550_remote_task_listener_mode/migration.sql
+++ b/packages/opencode/migration/20260726102550_remote_task_listener_mode/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `remote_task_listener` ADD `mode` text DEFAULT 'collab' NOT NULL;

--- a/packages/opencode/migration/20260726102550_remote_task_listener_mode/snapshot.json
+++ b/packages/opencode/migration/20260726102550_remote_task_listener_mode/snapshot.json
@@ -1,0 +1,4060 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "197c2bbe-59fd-4c56-9e31-7f319ad4b46d",
+  "prevIds": [
+    "86f6798f-77a8-4716-816a-46980eaf5508"
+  ],
+  "ddl": [
+    {
+      "name": "collab_agent",
+      "entityType": "tables"
+    },
+    {
+      "name": "collab_message",
+      "entityType": "tables"
+    },
+    {
+      "name": "workspace",
+      "entityType": "tables"
+    },
+    {
+      "name": "control_account",
+      "entityType": "tables"
+    },
+    {
+      "name": "project",
+      "entityType": "tables"
+    },
+    {
+      "name": "remote_task_listener",
+      "entityType": "tables"
+    },
+    {
+      "name": "article",
+      "entityType": "tables"
+    },
+    {
+      "name": "atom_relation",
+      "entityType": "tables"
+    },
+    {
+      "name": "atom",
+      "entityType": "tables"
+    },
+    {
+      "name": "code",
+      "entityType": "tables"
+    },
+    {
+      "name": "experiment_execution_watch",
+      "entityType": "tables"
+    },
+    {
+      "name": "experiment",
+      "entityType": "tables"
+    },
+    {
+      "name": "experiment_watch",
+      "entityType": "tables"
+    },
+    {
+      "name": "project_runtime_environment",
+      "entityType": "tables"
+    },
+    {
+      "name": "project_runtime_resource",
+      "entityType": "tables"
+    },
+    {
+      "name": "remote_server",
+      "entityType": "tables"
+    },
+    {
+      "name": "remote_task",
+      "entityType": "tables"
+    },
+    {
+      "name": "research_project",
+      "entityType": "tables"
+    },
+    {
+      "name": "message",
+      "entityType": "tables"
+    },
+    {
+      "name": "part",
+      "entityType": "tables"
+    },
+    {
+      "name": "permission",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "todo",
+      "entityType": "tables"
+    },
+    {
+      "name": "session_share",
+      "entityType": "tables"
+    },
+    {
+      "name": "workflow_instance",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_agent_id",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "root_agent_id",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "subagent_type",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "phase",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "spec_json",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "result_json",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error_json",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "active_children",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "spawned_total",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_started",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_ended",
+      "entityType": "columns",
+      "table": "collab_agent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recipient_agent_id",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sender_agent_id",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "payload_json",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_consumed",
+      "entityType": "columns",
+      "table": "collab_message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "branch",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "extra",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "workspace"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token_expiry",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "active",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "control_account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vcs",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_url",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "icon_color",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_initialized",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sandboxes",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "commands",
+      "entityType": "columns",
+      "table": "project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "remote_task_listener"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent_id",
+      "entityType": "columns",
+      "table": "remote_task_listener"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'collab'",
+      "generated": null,
+      "name": "mode",
+      "entityType": "columns",
+      "table": "remote_task_listener"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "remote_task_listener"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "remote_task_listener"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "article_id",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "research_project_id",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_url",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "article"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_id_source",
+      "entityType": "columns",
+      "table": "atom_relation"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_id_target",
+      "entityType": "columns",
+      "table": "atom_relation"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "relation_type",
+      "entityType": "columns",
+      "table": "atom_relation"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "atom_relation"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "atom_relation"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "atom_relation"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_id",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "research_project_id",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_name",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_type",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_claim_path",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_evidence_type",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "atom_evidence_status",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_evidence_path",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_evidence_assessment_path",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "article_id",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "atom"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code_id",
+      "entityType": "columns",
+      "table": "code"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "research_project_id",
+      "entityType": "columns",
+      "table": "code"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code_name",
+      "entityType": "columns",
+      "table": "code"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "article_id",
+      "entityType": "columns",
+      "table": "code"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "code"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "code"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "watch_id",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_id",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'planning'",
+      "generated": null,
+      "name": "stage",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_entity",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_project",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_run_id",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error_message",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_id",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'experiment'",
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "runtime_key",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "research_project_id",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_name",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_session_id",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "baseline_branch_name",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_branch_name",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_result_path",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "atom_id",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_result_summary_path",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_plan_path",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remote_server_id",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code_path",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remote_code_path",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "experiment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "watch_id",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_id",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_entity",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_project",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_api_key",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_run_id",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_polled_at",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "wandb_state",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error_message",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "experiment_watch"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "env_id",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "research_project_id",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remote_server_id",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "runtime_exp_id",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "env_key",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "conda_env_name",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "python_version",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "spec",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "fingerprint",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_verified_at",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error_message",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project_runtime_environment"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resource_id",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "research_project_id",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remote_server_id",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "runtime_exp_id",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resource_key",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_path",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "verify",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "fingerprint",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_verified_at",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error_message",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "project_runtime_resource"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "remote_server"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "remote_server"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "remote_server"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "remote_server"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task_id",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "exp_id",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resource_key",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "server",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remote_root",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_path",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "screen_name",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "command",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pid",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "log_path",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_selection",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "method",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error_message",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_polled_at",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stopped_at",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "remote_task"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "research_project_id",
+      "entityType": "columns",
+      "table": "research_project"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "research_project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "background_path",
+      "entityType": "columns",
+      "table": "research_project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "goal_path",
+      "entityType": "columns",
+      "table": "research_project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "macro_table_path",
+      "entityType": "columns",
+      "table": "research_project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "research_project"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "research_project"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "message"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "message_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "part"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "permission"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "project_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workspace_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "collab_peer",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "share_url",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_additions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_deletions",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_files",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary_diffs",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revert",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permission",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_compacting",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_archived",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "priority",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "position",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "todo"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "secret",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "session_share"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "template_id",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "flow_id",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "template_version",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "current_index",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "steps_json",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "context_json",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "workflow_instance"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_collab_agent_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "collab_agent"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_collab_agent_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "collab_agent"
+    },
+    {
+      "columns": [
+        "recipient_agent_id"
+      ],
+      "tableTo": "collab_agent",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_collab_message_recipient_agent_id_collab_agent_id_fk",
+      "entityType": "fks",
+      "table": "collab_message"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workspace_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "workspace"
+    },
+    {
+      "columns": [
+        "task_id"
+      ],
+      "tableTo": "remote_task",
+      "columnsTo": [
+        "task_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_remote_task_listener_task_id_remote_task_task_id_fk",
+      "entityType": "fks",
+      "table": "remote_task_listener"
+    },
+    {
+      "columns": [
+        "agent_id"
+      ],
+      "tableTo": "collab_agent",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_remote_task_listener_agent_id_collab_agent_id_fk",
+      "entityType": "fks",
+      "table": "remote_task_listener"
+    },
+    {
+      "columns": [
+        "research_project_id"
+      ],
+      "tableTo": "research_project",
+      "columnsTo": [
+        "research_project_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_article_research_project_id_research_project_research_project_id_fk",
+      "entityType": "fks",
+      "table": "article"
+    },
+    {
+      "columns": [
+        "atom_id_source"
+      ],
+      "tableTo": "atom",
+      "columnsTo": [
+        "atom_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_atom_relation_atom_id_source_atom_atom_id_fk",
+      "entityType": "fks",
+      "table": "atom_relation"
+    },
+    {
+      "columns": [
+        "atom_id_target"
+      ],
+      "tableTo": "atom",
+      "columnsTo": [
+        "atom_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_atom_relation_atom_id_target_atom_atom_id_fk",
+      "entityType": "fks",
+      "table": "atom_relation"
+    },
+    {
+      "columns": [
+        "research_project_id"
+      ],
+      "tableTo": "research_project",
+      "columnsTo": [
+        "research_project_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_atom_research_project_id_research_project_research_project_id_fk",
+      "entityType": "fks",
+      "table": "atom"
+    },
+    {
+      "columns": [
+        "article_id"
+      ],
+      "tableTo": "article",
+      "columnsTo": [
+        "article_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_atom_article_id_article_article_id_fk",
+      "entityType": "fks",
+      "table": "atom"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_atom_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "atom"
+    },
+    {
+      "columns": [
+        "research_project_id"
+      ],
+      "tableTo": "research_project",
+      "columnsTo": [
+        "research_project_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_code_research_project_id_research_project_research_project_id_fk",
+      "entityType": "fks",
+      "table": "code"
+    },
+    {
+      "columns": [
+        "article_id"
+      ],
+      "tableTo": "article",
+      "columnsTo": [
+        "article_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_code_article_id_article_article_id_fk",
+      "entityType": "fks",
+      "table": "code"
+    },
+    {
+      "columns": [
+        "exp_id"
+      ],
+      "tableTo": "experiment",
+      "columnsTo": [
+        "exp_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_experiment_execution_watch_exp_id_experiment_exp_id_fk",
+      "entityType": "fks",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "columns": [
+        "research_project_id"
+      ],
+      "tableTo": "research_project",
+      "columnsTo": [
+        "research_project_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_experiment_research_project_id_research_project_research_project_id_fk",
+      "entityType": "fks",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        "exp_session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_experiment_exp_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        "atom_id"
+      ],
+      "tableTo": "atom",
+      "columnsTo": [
+        "atom_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_experiment_atom_id_atom_atom_id_fk",
+      "entityType": "fks",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        "remote_server_id"
+      ],
+      "tableTo": "remote_server",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_experiment_remote_server_id_remote_server_id_fk",
+      "entityType": "fks",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        "exp_id"
+      ],
+      "tableTo": "experiment",
+      "columnsTo": [
+        "exp_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_experiment_watch_exp_id_experiment_exp_id_fk",
+      "entityType": "fks",
+      "table": "experiment_watch"
+    },
+    {
+      "columns": [
+        "research_project_id"
+      ],
+      "tableTo": "research_project",
+      "columnsTo": [
+        "research_project_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_project_runtime_environment_research_project_id_research_project_research_project_id_fk",
+      "entityType": "fks",
+      "table": "project_runtime_environment"
+    },
+    {
+      "columns": [
+        "remote_server_id"
+      ],
+      "tableTo": "remote_server",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_project_runtime_environment_remote_server_id_remote_server_id_fk",
+      "entityType": "fks",
+      "table": "project_runtime_environment"
+    },
+    {
+      "columns": [
+        "runtime_exp_id"
+      ],
+      "tableTo": "experiment",
+      "columnsTo": [
+        "exp_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_project_runtime_environment_runtime_exp_id_experiment_exp_id_fk",
+      "entityType": "fks",
+      "table": "project_runtime_environment"
+    },
+    {
+      "columns": [
+        "research_project_id"
+      ],
+      "tableTo": "research_project",
+      "columnsTo": [
+        "research_project_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_project_runtime_resource_research_project_id_research_project_research_project_id_fk",
+      "entityType": "fks",
+      "table": "project_runtime_resource"
+    },
+    {
+      "columns": [
+        "remote_server_id"
+      ],
+      "tableTo": "remote_server",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_project_runtime_resource_remote_server_id_remote_server_id_fk",
+      "entityType": "fks",
+      "table": "project_runtime_resource"
+    },
+    {
+      "columns": [
+        "runtime_exp_id"
+      ],
+      "tableTo": "experiment",
+      "columnsTo": [
+        "exp_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_project_runtime_resource_runtime_exp_id_experiment_exp_id_fk",
+      "entityType": "fks",
+      "table": "project_runtime_resource"
+    },
+    {
+      "columns": [
+        "exp_id"
+      ],
+      "tableTo": "experiment",
+      "columnsTo": [
+        "exp_id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_remote_task_exp_id_experiment_exp_id_fk",
+      "entityType": "fks",
+      "table": "remote_task"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_research_project_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "research_project"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_message_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "message"
+    },
+    {
+      "columns": [
+        "message_id"
+      ],
+      "tableTo": "message",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_part_message_id_message_id_fk",
+      "entityType": "fks",
+      "table": "part"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_permission_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "permission"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "tableTo": "project",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_project_id_project_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_todo_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_session_share_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "session_share"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workflow_instance_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "workflow_instance"
+    },
+    {
+      "columns": [
+        "email",
+        "url"
+      ],
+      "nameExplicit": false,
+      "name": "control_account_pk",
+      "entityType": "pks",
+      "table": "control_account"
+    },
+    {
+      "columns": [
+        "task_id",
+        "agent_id"
+      ],
+      "nameExplicit": false,
+      "name": "remote_task_listener_pk",
+      "entityType": "pks",
+      "table": "remote_task_listener"
+    },
+    {
+      "columns": [
+        "atom_id_source",
+        "atom_id_target",
+        "relation_type"
+      ],
+      "nameExplicit": false,
+      "name": "atom_relation_pk",
+      "entityType": "pks",
+      "table": "atom_relation"
+    },
+    {
+      "columns": [
+        "session_id",
+        "position"
+      ],
+      "nameExplicit": false,
+      "name": "todo_pk",
+      "entityType": "pks",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "collab_agent_pk",
+      "table": "collab_agent",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "collab_message_pk",
+      "table": "collab_message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workspace_pk",
+      "table": "workspace",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "project_pk",
+      "table": "project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "article_id"
+      ],
+      "nameExplicit": false,
+      "name": "article_pk",
+      "table": "article",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "atom_id"
+      ],
+      "nameExplicit": false,
+      "name": "atom_pk",
+      "table": "atom",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "code_id"
+      ],
+      "nameExplicit": false,
+      "name": "code_pk",
+      "table": "code",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "watch_id"
+      ],
+      "nameExplicit": false,
+      "name": "experiment_execution_watch_pk",
+      "table": "experiment_execution_watch",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "exp_id"
+      ],
+      "nameExplicit": false,
+      "name": "experiment_pk",
+      "table": "experiment",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "watch_id"
+      ],
+      "nameExplicit": false,
+      "name": "experiment_watch_pk",
+      "table": "experiment_watch",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "env_id"
+      ],
+      "nameExplicit": false,
+      "name": "project_runtime_environment_pk",
+      "table": "project_runtime_environment",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "resource_id"
+      ],
+      "nameExplicit": false,
+      "name": "project_runtime_resource_pk",
+      "table": "project_runtime_resource",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "remote_server_pk",
+      "table": "remote_server",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "task_id"
+      ],
+      "nameExplicit": false,
+      "name": "remote_task_pk",
+      "table": "remote_task",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "research_project_id"
+      ],
+      "nameExplicit": false,
+      "name": "research_project_pk",
+      "table": "research_project",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "message_pk",
+      "table": "message",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "part_pk",
+      "table": "part",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
+      "nameExplicit": false,
+      "name": "permission_pk",
+      "table": "permission",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "session_id"
+      ],
+      "nameExplicit": false,
+      "name": "session_share_pk",
+      "table": "session_share",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workflow_instance_pk",
+      "table": "workflow_instance",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "collab_agent_session_idx",
+      "entityType": "indexes",
+      "table": "collab_agent"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_agent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "collab_agent_parent_idx",
+      "entityType": "indexes",
+      "table": "collab_agent"
+    },
+    {
+      "columns": [
+        {
+          "value": "root_agent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "collab_agent_root_idx",
+      "entityType": "indexes",
+      "table": "collab_agent"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        },
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "collab_agent_project_status_idx",
+      "entityType": "indexes",
+      "table": "collab_agent"
+    },
+    {
+      "columns": [
+        {
+          "value": "recipient_agent_id",
+          "isExpression": false
+        },
+        {
+          "value": "status",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "collab_msg_recipient_pending_idx",
+      "entityType": "indexes",
+      "table": "collab_message"
+    },
+    {
+      "columns": [
+        {
+          "value": "agent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "remote_task_listener_agent_idx",
+      "entityType": "indexes",
+      "table": "remote_task_listener"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "article_research_project_idx",
+      "entityType": "indexes",
+      "table": "article"
+    },
+    {
+      "columns": [
+        {
+          "value": "atom_id_target",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "atom_relation_target_idx",
+      "entityType": "indexes",
+      "table": "atom_relation"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "atom_research_project_idx",
+      "entityType": "indexes",
+      "table": "atom"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "atom_session_idx",
+      "entityType": "indexes",
+      "table": "atom"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "code_research_project_idx",
+      "entityType": "indexes",
+      "table": "code"
+    },
+    {
+      "columns": [
+        {
+          "value": "article_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "code_article_idx",
+      "entityType": "indexes",
+      "table": "code"
+    },
+    {
+      "columns": [
+        {
+          "value": "exp_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_execution_watch_exp_idx",
+      "entityType": "indexes",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_execution_watch_status_idx",
+      "entityType": "indexes",
+      "table": "experiment_execution_watch"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_research_project_idx",
+      "entityType": "indexes",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        {
+          "value": "exp_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_session_idx",
+      "entityType": "indexes",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        {
+          "value": "atom_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_atom_idx",
+      "entityType": "indexes",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        {
+          "value": "runtime_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_runtime_key_idx",
+      "entityType": "indexes",
+      "table": "experiment"
+    },
+    {
+      "columns": [
+        {
+          "value": "exp_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_watch_exp_idx",
+      "entityType": "indexes",
+      "table": "experiment_watch"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "experiment_watch_status_idx",
+      "entityType": "indexes",
+      "table": "experiment_watch"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_env_project_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_environment"
+    },
+    {
+      "columns": [
+        {
+          "value": "remote_server_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_env_server_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_environment"
+    },
+    {
+      "columns": [
+        {
+          "value": "runtime_exp_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_env_runtime_exp_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_environment"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        },
+        {
+          "value": "remote_server_id",
+          "isExpression": false
+        },
+        {
+          "value": "env_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_env_key_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_environment"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_resource_project_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_resource"
+    },
+    {
+      "columns": [
+        {
+          "value": "remote_server_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_resource_server_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_resource"
+    },
+    {
+      "columns": [
+        {
+          "value": "runtime_exp_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_resource_runtime_exp_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_resource"
+    },
+    {
+      "columns": [
+        {
+          "value": "research_project_id",
+          "isExpression": false
+        },
+        {
+          "value": "remote_server_id",
+          "isExpression": false
+        },
+        {
+          "value": "resource_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "project_runtime_resource_key_idx",
+      "entityType": "indexes",
+      "table": "project_runtime_resource"
+    },
+    {
+      "columns": [
+        {
+          "value": "exp_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "remote_task_exp_idx",
+      "entityType": "indexes",
+      "table": "remote_task"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "remote_task_status_idx",
+      "entityType": "indexes",
+      "table": "remote_task"
+    },
+    {
+      "columns": [
+        {
+          "value": "exp_id",
+          "isExpression": false
+        },
+        {
+          "value": "kind",
+          "isExpression": false
+        },
+        {
+          "value": "resource_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "remote_task_exp_kind_resource_idx",
+      "entityType": "indexes",
+      "table": "remote_task"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "research_project_project_idx",
+      "entityType": "indexes",
+      "table": "research_project"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "message_session_idx",
+      "entityType": "indexes",
+      "table": "message"
+    },
+    {
+      "columns": [
+        {
+          "value": "message_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_message_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "part_session_idx",
+      "entityType": "indexes",
+      "table": "part"
+    },
+    {
+      "columns": [
+        {
+          "value": "project_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_project_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "workspace_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_workspace_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_parent_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "todo_session_idx",
+      "entityType": "indexes",
+      "table": "todo"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workflow_instance_session_idx",
+      "entityType": "indexes",
+      "table": "workflow_instance"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workflow_instance_status_idx",
+      "entityType": "indexes",
+      "table": "workflow_instance"
+    },
+    {
+      "columns": [
+        {
+          "value": "template_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workflow_instance_template_idx",
+      "entityType": "indexes",
+      "table": "workflow_instance"
+    }
+  ],
+  "renames": []
+}

--- a/packages/opencode/src/collab/agent-node.ts
+++ b/packages/opencode/src/collab/agent-node.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm"
+import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import { Database, NotFoundError } from "@/storage/db"
 import { Bus } from "@/bus"
 import { Log } from "@/util/log"
@@ -46,11 +46,13 @@ export namespace CollabAgentNode {
     rootAgentId: string
     subagentType: string
     spec: AgentSpec
+    status?: CollabAgentStatus
   }
 
   export function create(input: CreateInput): AgentInfo {
     const now = Date.now()
     const parentId = input.parentAgentId ?? null
+    const status = input.status ?? "pending"
 
     return Database.transaction((tx) => {
       tx.insert(CollabAgentTable)
@@ -62,7 +64,7 @@ export namespace CollabAgentNode {
           project_id: input.projectId,
           root_agent_id: input.rootAgentId,
           subagent_type: input.subagentType,
-          status: "pending",
+          status,
           phase: "main_loop",
           spec_json: input.spec as any,
           result_json: null,
@@ -79,7 +81,7 @@ export namespace CollabAgentNode {
       if (parentId) {
         tx.update(CollabAgentTable)
           .set({
-            active_children: sql`${CollabAgentTable.active_children} + 1`,
+            active_children: sql`${CollabAgentTable.active_children} + ${isActive(status) ? 1 : 0}`,
             spawned_total: sql`${CollabAgentTable.spawned_total} + 1`,
             time_updated: now,
           })
@@ -194,6 +196,222 @@ export namespace CollabAgentNode {
     return info
   }
 
+  export function activate(id: string): AgentInfo {
+    const now = Date.now()
+    return Database.transaction((tx) => {
+      const current = tx.select().from(CollabAgentTable).where(eq(CollabAgentTable.id, id)).get()
+      if (!current) throw new NotFoundError({ message: `Agent not found: ${id}` })
+      if (isActive(current.status)) return fromRow(current)
+
+      const row = tx
+        .update(CollabAgentTable)
+        .set({
+          status: "running",
+          phase: "main_loop",
+          error_json: null,
+          time_ended: null,
+          time_started: now,
+          time_updated: now,
+        })
+        .where(eq(CollabAgentTable.id, id))
+        .returning()
+        .get()
+      if (!row) throw new NotFoundError({ message: `Agent not found: ${id}` })
+
+      if (current.parent_agent_id) {
+        tx.update(CollabAgentTable)
+          .set({
+            active_children: sql`${CollabAgentTable.active_children} + 1`,
+            time_updated: now,
+          })
+          .where(eq(CollabAgentTable.id, current.parent_agent_id))
+          .run()
+      }
+
+      const info = fromRow(row)
+      Database.effect(() =>
+        Bus.publish(CollabEvent.AgentStatus, {
+          agentId: info.id,
+          rootAgentId: info.root_agent_id,
+          status: info.status,
+          phase: info.phase,
+          active_children: info.active_children,
+        }),
+      )
+      return info
+    })
+  }
+
+  export function spec(id: string, spec: AgentSpec): AgentInfo {
+    const row = Database.use((db) =>
+      db
+        .update(CollabAgentTable)
+        .set({ spec_json: spec, time_updated: Date.now() })
+        .where(eq(CollabAgentTable.id, id))
+        .returning()
+        .get(),
+    )
+    if (!row) throw new NotFoundError({ message: `Agent not found: ${id}` })
+    return fromRow(row)
+  }
+
+  export function attach(input: {
+    id: string
+    parentId: string
+    rootId: string
+    name: string
+    subagentType: string
+    metadata: Record<string, unknown>
+  }): AgentInfo {
+    const now = Date.now()
+    return Database.transaction((tx) => {
+      const current = tx.select().from(CollabAgentTable).where(eq(CollabAgentTable.id, input.id)).get()
+      if (!current) throw new NotFoundError({ message: `Agent not found: ${input.id}` })
+      const parent = tx.select().from(CollabAgentTable).where(eq(CollabAgentTable.id, input.parentId)).get()
+      if (!parent) throw new NotFoundError({ message: `Parent agent not found: ${input.parentId}` })
+      if (current.parent_agent_id === input.parentId && current.root_agent_id === input.rootId) return fromRow(current)
+      if (parent.root_agent_id !== input.rootId) throw new Error(`Parent ${input.parentId} is not in root ${input.rootId}`)
+      if (parent.project_id !== current.project_id) throw new Error(`Agent ${input.id} project mismatch`)
+
+      const tree = tx
+        .select({ id: CollabAgentTable.id, parent: CollabAgentTable.parent_agent_id })
+        .from(CollabAgentTable)
+        .where(eq(CollabAgentTable.root_agent_id, current.root_agent_id))
+        .all()
+      const ids = new Set([current.id])
+      let changed = true
+      while (changed) {
+        changed = false
+        for (const item of tree) {
+          if (!item.parent || !ids.has(item.parent) || ids.has(item.id)) continue
+          ids.add(item.id)
+          changed = true
+        }
+      }
+      if (ids.has(parent.id)) throw new Error(`Attaching ${input.id} would create a cycle`)
+
+      tx.update(CollabAgentTable)
+        .set({ root_agent_id: input.rootId, time_updated: now })
+        .where(inArray(CollabAgentTable.id, [...ids]))
+        .run()
+      const row = tx
+        .update(CollabAgentTable)
+        .set({
+          parent_agent_id: input.parentId,
+          name: input.name,
+          subagent_type: input.subagentType,
+          status: "idle",
+          phase: "main_loop",
+          spec_json: {
+            ...(current.spec_json as AgentSpec),
+            metadata: {
+              ...(current.spec_json as AgentSpec).metadata,
+              ...input.metadata,
+            },
+          },
+          time_updated: now,
+        })
+        .where(eq(CollabAgentTable.id, input.id))
+        .returning()
+        .get()
+      if (!row) throw new NotFoundError({ message: `Agent not found: ${input.id}` })
+
+      if (current.parent_agent_id && isActive(current.status)) {
+        tx.update(CollabAgentTable)
+          .set({
+            active_children: sql`max(${CollabAgentTable.active_children} - 1, 0)`,
+            time_updated: now,
+          })
+          .where(eq(CollabAgentTable.id, current.parent_agent_id))
+          .run()
+      }
+
+      tx.update(CollabAgentTable)
+        .set({
+          spawned_total: sql`${CollabAgentTable.spawned_total} + 1`,
+          time_updated: now,
+        })
+        .where(eq(CollabAgentTable.id, input.parentId))
+        .run()
+
+      const info = fromRow(row)
+      Database.effect(() => Bus.publish(CollabEvent.AgentCreated, { info }))
+      log.info("attached", { id: input.id, parent: input.parentId, root: input.rootId })
+      return info
+    })
+  }
+
+  export function rebind(id: string, sessionId: string) {
+    const row = Database.use((db) =>
+      db
+        .update(CollabAgentTable)
+        .set({ session_id: sessionId, time_updated: Date.now() })
+        .where(eq(CollabAgentTable.id, id))
+        .returning()
+        .get(),
+    )
+    if (!row) throw new NotFoundError({ message: `Agent not found: ${id}` })
+    const info = fromRow(row)
+    Database.effect(() => Bus.publish(CollabEvent.AgentCreated, { info }))
+    return info
+  }
+
+  export function drop(id: string, reported = false) {
+    Database.transaction((tx) => {
+      const current = tx.select().from(CollabAgentTable).where(eq(CollabAgentTable.id, id)).get()
+      if (!current) return
+      if (current.parent_agent_id && isActive(current.status) && !reported) {
+        tx.update(CollabAgentTable)
+          .set({
+            active_children: sql`max(${CollabAgentTable.active_children} - 1, 0)`,
+            time_updated: Date.now(),
+          })
+          .where(eq(CollabAgentTable.id, current.parent_agent_id))
+          .run()
+      }
+      tx.delete(CollabAgentTable).where(eq(CollabAgentTable.id, id)).run()
+    })
+  }
+
+  export function detach(id: string) {
+    Database.transaction((tx) => {
+      const current = tx.select().from(CollabAgentTable).where(eq(CollabAgentTable.id, id)).get()
+      if (!current?.parent_agent_id) return
+      const tree = tx
+        .select({ id: CollabAgentTable.id, parent: CollabAgentTable.parent_agent_id })
+        .from(CollabAgentTable)
+        .where(eq(CollabAgentTable.root_agent_id, current.root_agent_id))
+        .all()
+      const ids = new Set([current.id])
+      let changed = true
+      while (changed) {
+        changed = false
+        for (const item of tree) {
+          if (!item.parent || !ids.has(item.parent) || ids.has(item.id)) continue
+          ids.add(item.id)
+          changed = true
+        }
+      }
+      tx.update(CollabAgentTable)
+        .set({ root_agent_id: current.id, time_updated: Date.now() })
+        .where(inArray(CollabAgentTable.id, [...ids]))
+        .run()
+      tx.update(CollabAgentTable)
+        .set({ parent_agent_id: null, time_updated: Date.now() })
+        .where(eq(CollabAgentTable.id, current.id))
+        .run()
+      if (isActive(current.status)) {
+        tx.update(CollabAgentTable)
+          .set({
+            active_children: sql`max(${CollabAgentTable.active_children} - 1, 0)`,
+            time_updated: Date.now(),
+          })
+          .where(eq(CollabAgentTable.id, current.parent_agent_id))
+          .run()
+      }
+    })
+  }
+
   export function updatePhase(id: string, phase: CollabAgentPhase): AgentInfo {
     const now = Date.now()
     const row = Database.use((db) =>
@@ -223,7 +441,8 @@ export namespace CollabAgentNode {
       db
         .select({ session_id: CollabAgentTable.session_id })
         .from(CollabAgentTable)
-        .where(and(eq(CollabAgentTable.project_id, projectId), isNotNull(CollabAgentTable.parent_agent_id)))
+        .innerJoin(SessionTable, eq(SessionTable.id, CollabAgentTable.session_id))
+        .where(and(eq(CollabAgentTable.project_id, projectId), eq(SessionTable.collab_peer, true)))
         .all(),
     ).map((r) => r.session_id)
   }
@@ -243,7 +462,7 @@ export namespace CollabAgentNode {
         .innerJoin(SessionTable, eq(SessionTable.id, CollabAgentTable.session_id))
         .where(
           and(
-            isNotNull(CollabAgentTable.parent_agent_id),
+            eq(SessionTable.collab_peer, true),
             // either project_id matches or the session directory matches —
             // be permissive so stale rows still resolve.
             sql`(${CollabAgentTable.project_id} = ${projectId} OR ${SessionTable.directory} = ${directory})`,

--- a/packages/opencode/src/collab/auto-wake.ts
+++ b/packages/opencode/src/collab/auto-wake.ts
@@ -1,8 +1,10 @@
 import { Bus } from "@/bus"
 import { Instance } from "@/project/instance"
 import { Log } from "@/util/log"
+import { Session } from "@/session"
 import { SessionPrompt } from "@/session/prompt"
 import { SessionStatus } from "@/session/status"
+import { SessionOwnership } from "@/session/ownership"
 import { CollabAgentNode } from "./agent-node"
 import { CollabMessage } from "./message"
 import { CollabSupervisor } from "./supervisor"
@@ -58,6 +60,12 @@ export namespace CollabAutoWake {
       const unsubMsg = Bus.subscribe(CollabEvent.MessagePosted, (e) => {
         if (!enabled) return
         const { recipientAgentId, kind } = e.properties
+        if (kind === "session_remote_task_terminal") {
+          void tryDriveDirectById(recipientAgentId, inflight).catch((err) =>
+            log.error("onDirectMessagePosted", { recipientAgentId, error: String(err) }),
+          )
+          return
+        }
         if (!(WAKE_MESSAGE_KINDS as readonly string[]).includes(kind)) return
         void tryDriveById(recipientAgentId, inflight).catch((err) =>
           log.error("onMessagePosted", { recipientAgentId, error: String(err) }),
@@ -72,6 +80,13 @@ export namespace CollabAutoWake {
         )
       })
 
+      const unsubAgent = Bus.subscribe(CollabEvent.AgentStatus, (e) => {
+        if (!enabled) return
+        void tryDriveDirectById(e.properties.agentId, inflight).catch((err) =>
+          log.error("onAgentStatus", { agentId: e.properties.agentId, error: String(err) }),
+        )
+      })
+
       // also scan existing idle roots on startup
       queueMicrotask(() => {
         if (!enabled) return
@@ -82,11 +97,12 @@ export namespace CollabAutoWake {
         }
       })
 
-      return { inflight, unsubMsg, unsubIdle }
+      return { inflight, unsubMsg, unsubIdle, unsubAgent }
     },
     async (s) => {
       s.unsubMsg()
       s.unsubIdle()
+      s.unsubAgent()
       s.inflight.clear()
     },
   )
@@ -111,21 +127,46 @@ export namespace CollabAutoWake {
 
   function scanExistingRoots(inflight: Set<string>) {
     const project = Instance.project
+    for (const row of CollabMessage.direct(project.id)) {
+      void tryDriveDirectById(row.agentId, inflight).catch((err) =>
+        log.error("initialScan.direct", { id: row.agentId, error: String(err) }),
+      )
+    }
     const active = CollabAgentNode.loadActiveByProject(project.id)
     for (const node of active) {
-      if (node.parent_agent_id) {
-        maybeStartLoop(node)
-        continue
-      }
-      void maybeWakeOrBlock(node, inflight).catch((err) =>
+      void tryDriveById(node.id, inflight).catch((err) =>
         log.error("initialScan.node", { id: node.id, error: String(err) }),
       )
     }
   }
 
-  async function tryDriveById(agentId: string, inflight: Set<string>) {
-    const node = CollabAgentNode.tryLoad(agentId)
-    if (!node) return
+  async function route(
+    node: AgentInfo,
+    inflight: Set<string>,
+    drive: (fresh: AgentInfo, current: Set<string>) => void | Promise<void>,
+  ) {
+    const session = await Session.get(node.session_id)
+    if (session.directory === Instance.directory) return drive(node, inflight)
+    return Instance.provide({
+      directory: session.directory,
+      init: async () => {
+        const { InstanceBootstrap } = await import("@/project/bootstrap")
+        await InstanceBootstrap()
+      },
+      async fn() {
+        ensure()
+        const fresh = CollabAgentNode.tryLoad(node.id)
+        if (!fresh) return
+        await drive(fresh, state().inflight)
+      },
+    })
+  }
+
+  async function driveNode(node: AgentInfo, inflight: Set<string>) {
+    if (CollabMessage.hasPendingKind(node.id, "session_remote_task_terminal")) {
+      await maybeDriveDirect(node, inflight)
+      return
+    }
     if (!CollabAgentNode.isActive(node.status)) return
     if (node.parent_agent_id) {
       maybeStartLoop(node)
@@ -134,15 +175,65 @@ export namespace CollabAutoWake {
     await maybeWakeOrBlock(node, inflight)
   }
 
+  async function tryDriveById(agentId: string, inflight: Set<string>) {
+    const node = CollabAgentNode.tryLoad(agentId)
+    if (!node) return
+    await route(node, inflight, driveNode)
+  }
+
   async function tryDriveBySession(sessionID: string, inflight: Set<string>) {
     const node = CollabAgentNode.loadBySessionId(sessionID)
     if (!node) return
-    if (!CollabAgentNode.isActive(node.status)) return
-    if (node.parent_agent_id) {
-      maybeStartLoop(node)
+    await route(node, inflight, driveNode)
+  }
+
+  async function tryDriveDirectById(agentId: string, inflight: Set<string>) {
+    const node = CollabAgentNode.tryLoad(agentId)
+    if (!node) return
+    await route(node, inflight, maybeDriveDirect)
+  }
+
+  async function maybeDriveDirect(node: AgentInfo, inflight: Set<string>) {
+    if (inflight.has(node.session_id)) return
+    if (SessionStatus.get(node.session_id).type === "busy") return
+    if (!CollabMessage.hasPendingKind(node.id, "session_remote_task_terminal")) return
+
+    const release = SessionOwnership.claim(node.session_id, "human")
+    if (!release) return
+    inflight.add(node.session_id)
+    try {
+      for (let i = 0; i < MAX_DRIVE_ITERATIONS; i++) {
+        if (SessionStatus.get(node.session_id).type === "busy") return
+        if (!CollabMessage.hasPendingKind(node.id, "session_remote_task_terminal")) return
+        await driveDirect(node.id)
+      }
+      log.warn("maybeDriveDirect hit MAX_DRIVE_ITERATIONS cap", { agentId: node.id })
+    } finally {
+      inflight.delete(node.session_id)
+      release()
+    }
+  }
+
+  async function driveDirect(agentId: string) {
+    if (driveTurnOverride) {
+      await driveTurnOverride(agentId)
       return
     }
-    await maybeWakeOrBlock(node, inflight)
+    const node = CollabAgentNode.load(agentId)
+    const msgs = CollabMessage.drain(agentId, "direct")
+    const parts = msgs.map((msg) => buildRemoteTaskTerminalPart(msg.payload_json as RemoteTaskTerminalPayload))
+    if (!parts.length) return
+    try {
+      await SessionPrompt.prompt({
+        sessionID: node.session_id,
+        agent: node.subagent_type,
+        model: node.spec.model,
+        parts: finalizeParts(parts),
+      })
+    } catch (err) {
+      CollabMessage.retry(msgs.map((msg) => msg.id))
+      throw err
+    }
   }
 
   function maybeStartLoop(node: AgentInfo) {

--- a/packages/opencode/src/collab/collab.sql.ts
+++ b/packages/opencode/src/collab/collab.sql.ts
@@ -4,6 +4,7 @@ import { ProjectTable } from "../project/project.sql"
 import { Timestamps } from "@/storage/schema.sql"
 
 export const collabAgentStatuses = [
+  "idle",
   "pending",
   "running",
   "blocked_on_children",
@@ -23,6 +24,7 @@ export const collabMsgKinds = [
   "child_waiting",
   "child_progress",
   "remote_task_terminal",
+  "session_remote_task_terminal",
   "cancel",
   "user_input",
   "system",

--- a/packages/opencode/src/collab/index.ts
+++ b/packages/opencode/src/collab/index.ts
@@ -8,6 +8,7 @@ import { Bus } from "@/bus"
 import { NotFoundError } from "@/storage/db"
 import { PermissionNext } from "@/permission/next"
 import { SessionStatus } from "@/session/status"
+import { SessionOwnership } from "@/session/ownership"
 import { CollabAgentNode } from "./agent-node"
 import { CollabMessage } from "./message"
 import { CollabLoop } from "./loop"
@@ -161,14 +162,31 @@ export namespace Collab {
    * consuming the new prompt. Waiting agents remain active children; terminal
    * agents are re-counted as active before their additional turn.
    */
-  export async function resume(input: { agentId: string; prompt: string }): Promise<AgentInfo> {
+  export async function resume(input: {
+    agentId: string
+    prompt: string
+    model?: { providerID: string; modelID: string }
+  }): Promise<AgentInfo> {
     CollabProgressHook.ensure()
     CollabAutoWake.ensure()
 
-    const node = CollabAgentNode.tryLoad(input.agentId)
+    let node = CollabAgentNode.tryLoad(input.agentId)
     if (!node) throw new NotFoundError({ message: `Agent not found: ${input.agentId}` })
+    node =
+      (await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.recover(input.agentId))) ?? node
+    if (
+      ExperimentRemoteTaskListener.has(node.id, "direct") ||
+      CollabMessage.hasPendingKind(node.id, "session_remote_task_terminal")
+    ) {
+      throw new Error(`Cannot resume agent ${node.id}: its human session is waiting for a remote task update.`)
+    }
 
     const waiting = node.status === "waiting_interaction"
+
+    if (!SessionOwnership.available(node.session_id, "collab")) throw new Session.BusyError(node.session_id)
+    if (!CollabAgentNode.isActive(node.status) && SessionStatus.get(node.session_id).type === "busy") {
+      throw new Session.BusyError(node.session_id)
+    }
 
     // If the parent has also finalized, resuming would orphan the child —
     // no one to receive `child_done`. Refuse.
@@ -186,7 +204,7 @@ export namespace Collab {
         recipientAgentId: node.id,
         senderAgentId: null,
         kind: "user_input",
-        payload: { text: input.prompt },
+        payload: { text: input.prompt, model: input.model },
       })
 
       if (SessionStatus.get(node.session_id).type !== "busy" && !CollabRuntime.has(node.id)) {
@@ -205,13 +223,10 @@ export namespace Collab {
     // 1) Transition child back to running; clear prior error but keep result
     //    history. 2) Re-bump parent's active_children only for terminal
     //    resumes. Waiting children never left the active count.
-    CollabAgentNode.transition(node.id, "running", {
-      phase: "main_loop",
-      error: null,
-      timeEnded: null,
-    })
-    if (node.parent_agent_id && !waiting) {
-      CollabAgentNode.bumpActiveChildren(node.parent_agent_id, 1)
+    if (waiting) {
+      CollabAgentNode.transition(node.id, "running", { phase: "main_loop" })
+    } else {
+      CollabAgentNode.activate(node.id)
     }
 
     // Post the instruction into its inbox BEFORE starting the loop, so the
@@ -221,7 +236,7 @@ export namespace Collab {
       recipientAgentId: node.id,
       senderAgentId: null,
       kind: "user_input",
-      payload: { text: input.prompt },
+      payload: { text: input.prompt, model: input.model },
     })
 
     void CollabLoop.start(node.id)
@@ -295,7 +310,7 @@ export namespace Collab {
       ),
       hasWaitingChildren: children.some((child) => child.status === "waiting_interaction"),
       hasPendingWakeMessages: CollabMessage.hasPendingWakeMsg(node.id),
-      hasRemoteTaskListeners: !!ExperimentRemoteTaskListener.has(node.id),
+      hasRemoteTaskListeners: !!ExperimentRemoteTaskListener.has(node.id, "collab"),
     }
   }
 
@@ -377,7 +392,7 @@ export namespace Collab {
       if (!node) return true
       if (!CollabAgentNode.isActive(node.status)) return true
       if (node.active_children > 0) return false
-      if (ExperimentRemoteTaskListener.has(rootAgentId)) return false
+      if (ExperimentRemoteTaskListener.has(rootAgentId, "collab")) return false
       if (CollabMessage.hasPendingWakeMsg(rootAgentId)) return false
       if (SessionStatus.get(sessionId).type !== "idle") return false
       // AutoWake's maybeWakeOrBlock claims the inflight lock before it

--- a/packages/opencode/src/collab/loop.ts
+++ b/packages/opencode/src/collab/loop.ts
@@ -1,8 +1,11 @@
 import { Bus } from "@/bus"
+import { GlobalBus } from "@/bus/global"
 import { Log } from "@/util/log"
+import { Instance } from "@/project/instance"
 import { Session } from "@/session"
 import { SessionPrompt } from "@/session/prompt"
 import { MessageV2 } from "@/session/message-v2"
+import { Provider } from "@/provider/provider"
 import { Workflow } from "@/workflow"
 import { ExperimentRemoteTaskListener } from "@/research/experiment-remote-task-listener"
 import { CollabAgentNode } from "./agent-node"
@@ -34,16 +37,36 @@ import type {
 
 export namespace CollabLoop {
   const log = Log.create({ service: "collab.loop" })
+  const waiters = new Map<string, Set<() => void>>()
 
-  export function start(agentId: string): Promise<void> {
+  GlobalBus.on("event", (e) => {
+    if (e.payload.type !== CollabEvent.MessagePosted.type) return
+    const props = e.payload.properties as { recipientAgentId?: string; kind?: string }
+    if (!props.recipientAgentId || !isWakeKind(props.kind ?? "")) return
+    for (const wake of [...(waiters.get(props.recipientAgentId) ?? [])]) wake()
+  })
+
+  export async function start(agentId: string): Promise<void> {
+    const node = CollabAgentNode.load(agentId)
+    const session = await Session.get(node.session_id)
+    if (session.directory !== Instance.directory) {
+      return Instance.provide({
+        directory: session.directory,
+        fn: () => start(agentId),
+      })
+    }
     if (CollabRuntime.has(agentId)) {
       log.warn("loop already running", { agentId })
       return CollabRuntime.get(agentId)!.promise
     }
     const abort = new AbortController()
-    const promise = runLoop(agentId, abort.signal).catch((err) => {
+    const promise = runLoop(agentId, abort.signal).catch(async (err) => {
       log.error("loop crashed", { agentId, error: String(err) })
-      void markLoopFailed(agentId, err)
+      if (Provider.ModelNotFoundError.isInstance(err) || err instanceof SessionPrompt.ModelUnavailableError) {
+        await waitForModel(agentId, err)
+        return
+      }
+      await markLoopFailed(agentId, err)
     })
     CollabRuntime.register(agentId, abort, promise)
     return promise
@@ -62,6 +85,31 @@ export namespace CollabLoop {
     } catch (e) {
       log.error("markLoopFailed failed", { agentId, error: String(e) })
     }
+  }
+
+  async function waitForModel(agentId: string, err: unknown) {
+    const node = CollabAgentNode.tryLoad(agentId)
+    if (!node || !CollabAgentNode.isActive(node.status)) return
+    const unavailable = Provider.ModelNotFoundError.isInstance(err)
+      ? `${err.data.providerID}/${err.data.modelID}`
+      : "the configured models"
+    const message = `Model ${unavailable} is unavailable. Resume this same agent after selecting an available model.`
+    if (!node.parent_agent_id) {
+      CollabAgentNode.transition(node.id, "waiting_interaction", { phase: "main_loop" })
+      return
+    }
+    await CollabMessage.postChildWaiting({
+      agentId: node.id,
+      rootAgentId: node.root_agent_id,
+      recipientAgentId: node.parent_agent_id,
+      payload: {
+        childAgentId: node.id,
+        childName: node.name,
+        childSessionId: node.session_id,
+        reason: "model_unavailable",
+        message,
+      },
+    })
   }
 
   async function runLoop(agentId: string, abort: AbortSignal) {
@@ -102,6 +150,7 @@ export namespace CollabLoop {
       const injections: PromptPartDraft[] = []
       const progressMsgs: ChildProgressPayload[] = []
       let failFastTrigger: ChildFailedPayload | undefined
+      let fallback: UserInputPayload["model"]
 
       for (const m of msgs) {
         const payload = m.payload_json as unknown
@@ -138,6 +187,7 @@ export namespace CollabLoop {
           }
           case "user_input": {
             const p = payload as UserInputPayload
+            fallback = p.model ?? fallback
             Workflow.autoResume({
               sessionID: node.session_id,
               userMessageID: p.messageId ?? m.id,
@@ -178,7 +228,7 @@ export namespace CollabLoop {
 
       if (injections.length > 0) {
         if (abort.aborted) return
-        await runPromptTurn(node, { parts: finalizeParts(injections) }, abort)
+        await runPromptTurn(node, { parts: finalizeParts(injections), fallback }, abort)
         if (await pauseIfWorkflowWaiting(agentId, abort)) return
         firstTick = false
         hasRunInitialPrompt = true
@@ -195,7 +245,11 @@ export namespace CollabLoop {
       }
 
       const refreshed = CollabAgentNode.load(agentId)
-      if (refreshed.active_children === 0 && !ExperimentRemoteTaskListener.has(refreshed.id)) {
+      if (
+        refreshed.active_children === 0 &&
+        !ExperimentRemoteTaskListener.has(refreshed.id, "collab") &&
+        !CollabMessage.hasPendingWakeMsg(refreshed.id)
+      ) {
         const inst = Workflow.latest(refreshed.session_id)
         if (inst?.status === "waiting_interaction") {
           if (await pauseIfWorkflowWaiting(agentId, abort)) return
@@ -218,8 +272,8 @@ export namespace CollabLoop {
           hasRunInitialPrompt = true
           continue
         }
-        await finalizeCompleted(refreshed)
-        return
+        if (await finalizeCompleted(refreshed)) return
+        continue
       }
 
       CollabAgentNode.transition(agentId, "blocked_on_children", { phase: "awaiting_children" })
@@ -231,16 +285,27 @@ export namespace CollabLoop {
 
   async function runPromptTurn(
     node: AgentInfo,
-    input: { parts: PromptPartDraft[] },
+    input: { parts: PromptPartDraft[]; fallback?: { providerID: string; modelID: string } },
     abort: AbortSignal,
   ) {
+    const model = input.fallback
+      ? await SessionPrompt.resolveModel({
+          sessionID: node.session_id,
+          agent: node.subagent_type,
+          preferred: node.spec.model,
+          fallback: input.fallback,
+        })
+      : node.spec.model
+    if (input.fallback && model) {
+      CollabAgentNode.spec(node.id, { ...node.spec, model })
+    }
     const onAbort = () => SessionPrompt.cancel(node.session_id)
     abort.addEventListener("abort", onAbort, { once: true })
     try {
       await SessionPrompt.prompt({
         sessionID: node.session_id,
         agent: node.subagent_type,
-        model: node.spec.model,
+        model,
         parts: input.parts,
       })
     } catch (err) {
@@ -293,16 +358,16 @@ export namespace CollabLoop {
       const finish = () => {
         if (done) return
         done = true
-        unsub()
+        const waits = waiters.get(agentId)
+        waits?.delete(finish)
+        if (waits?.size === 0) waiters.delete(agentId)
         abort.removeEventListener("abort", onAbort)
         resolve()
       }
-      const unsub = Bus.subscribe(CollabEvent.MessagePosted, (e) => {
-        if (e.properties.recipientAgentId !== agentId) return
-        if (!isWakeKind(e.properties.kind)) return
-        finish()
-      })
       const onAbort = () => finish()
+      const waits = waiters.get(agentId) ?? new Set()
+      waits.add(finish)
+      waiters.set(agentId, waits)
       abort.addEventListener("abort", onAbort)
       if (CollabMessage.hasPendingWakeMsg(agentId)) finish()
     })
@@ -321,35 +386,41 @@ export namespace CollabLoop {
 
   async function finalizeCompleted(node: AgentInfo) {
     const summary = await extractSessionSummary(node.session_id)
+    const fresh = CollabAgentNode.load(node.id)
+    if (!CollabAgentNode.isActive(fresh.status)) return false
+    if (fresh.active_children > 0) return false
+    if (ExperimentRemoteTaskListener.has(fresh.id, "collab")) return false
+    if (CollabMessage.hasPendingWakeMsg(fresh.id)) return false
     const result: AgentResult = { summary: summary ?? undefined }
 
-    CollabAgentNode.transition(node.id, "completed", {
+    CollabAgentNode.transition(fresh.id, "completed", {
       phase: "main_loop",
       result,
       timeEnded: Date.now(),
     })
-    CollabMessage.closeInbox(node.id)
+    CollabMessage.closeInbox(fresh.id)
 
-    if (node.parent_agent_id) {
+    if (fresh.parent_agent_id) {
       const payload: ChildDonePayload = {
-        childAgentId: node.id,
-        childName: node.name,
+        childAgentId: fresh.id,
+        childName: fresh.name,
         summary: summary ?? "",
       }
       await CollabMessage.post({
-        recipientAgentId: node.parent_agent_id,
-        senderAgentId: node.id,
+        recipientAgentId: fresh.parent_agent_id,
+        senderAgentId: fresh.id,
         kind: "child_done",
         payload,
       })
     }
 
     Bus.publish(CollabEvent.AgentCompleted, {
-      agentId: node.id,
-      rootAgentId: node.root_agent_id,
+      agentId: fresh.id,
+      rootAgentId: fresh.root_agent_id,
       summary: summary ?? undefined,
     })
-    log.info("completed", { agentId: node.id })
+    log.info("completed", { agentId: fresh.id })
+    return true
   }
 
   async function finalizeFailed(node: AgentInfo, error: AgentError) {

--- a/packages/opencode/src/collab/message.ts
+++ b/packages/opencode/src/collab/message.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, sql } from "drizzle-orm"
+import { and, asc, eq, inArray, ne, sql } from "drizzle-orm"
 import { Database } from "@/storage/db"
 import { Bus } from "@/bus"
 import { Identifier } from "@/id/id"
@@ -124,14 +124,22 @@ export namespace CollabMessage {
     return id
   }
 
-  export function drain(agentId: string): Row[] {
+  export function drain(agentId: string, mode: "collab" | "direct" = "collab"): Row[] {
     const consumedAt = Date.now()
 
     return Database.transaction((tx) => {
       const rows = tx
         .select()
         .from(CollabMessageTable)
-        .where(and(eq(CollabMessageTable.recipient_agent_id, agentId), eq(CollabMessageTable.status, "pending")))
+        .where(
+          and(
+            eq(CollabMessageTable.recipient_agent_id, agentId),
+            eq(CollabMessageTable.status, "pending"),
+            mode === "direct"
+              ? eq(CollabMessageTable.kind, "session_remote_task_terminal")
+              : ne(CollabMessageTable.kind, "session_remote_task_terminal"),
+          ),
+        )
         .orderBy(asc(CollabMessageTable.id))
         .limit(DRAIN_BATCH)
         .all()
@@ -192,6 +200,41 @@ export namespace CollabMessage {
     })
   }
 
+  export function hasPendingKind(agentId: string, kind: CollabMsgKind): boolean {
+    return Database.use((db) => {
+      const row = db
+        .select({ id: CollabMessageTable.id })
+        .from(CollabMessageTable)
+        .where(
+          and(
+            eq(CollabMessageTable.recipient_agent_id, agentId),
+            eq(CollabMessageTable.status, "pending"),
+            eq(CollabMessageTable.kind, kind),
+          ),
+        )
+        .limit(1)
+        .get()
+      return !!row
+    })
+  }
+
+  export function direct(projectId: string) {
+    return Database.use((db) =>
+      db
+        .selectDistinct({ agentId: CollabMessageTable.recipient_agent_id })
+        .from(CollabMessageTable)
+        .innerJoin(CollabAgentTable, eq(CollabAgentTable.id, CollabMessageTable.recipient_agent_id))
+        .where(
+          and(
+            eq(CollabAgentTable.project_id, projectId),
+            eq(CollabMessageTable.status, "pending"),
+            eq(CollabMessageTable.kind, "session_remote_task_terminal"),
+          ),
+        )
+        .all(),
+    )
+  }
+
   export function pendingWakeKinds(agentId: string): Set<CollabMsgKind> {
     return Database.use((db) => {
       const rows = db
@@ -214,9 +257,33 @@ export namespace CollabMessage {
     Database.use((db) => {
       db.update(CollabMessageTable)
         .set({ status: "dropped", time_updated: now })
-        .where(and(eq(CollabMessageTable.recipient_agent_id, agentId), eq(CollabMessageTable.status, "pending")))
+        .where(
+          and(
+            eq(CollabMessageTable.recipient_agent_id, agentId),
+            eq(CollabMessageTable.status, "pending"),
+            ne(CollabMessageTable.kind, "session_remote_task_terminal"),
+          ),
+        )
         .run()
     })
+  }
+
+  export function retry(ids: string[]) {
+    if (!ids.length) return
+    const now = Date.now()
+    return Database.use((db) =>
+      db
+        .update(CollabMessageTable)
+        .set({ status: "pending", time_consumed: null, time_updated: now })
+        .where(
+          and(
+            inArray(CollabMessageTable.id, ids),
+            eq(CollabMessageTable.kind, "session_remote_task_terminal"),
+            eq(CollabMessageTable.status, "consumed"),
+          ),
+        )
+        .run(),
+    )
   }
 
   export function list(agentId: string, opts?: { kind?: CollabMsgKind; limit?: number }) {

--- a/packages/opencode/src/collab/types.ts
+++ b/packages/opencode/src/collab/types.ts
@@ -132,6 +132,12 @@ export type CancelPayload = z.infer<typeof CancelPayloadSchema>
 export const UserInputPayloadSchema = z.object({
   text: z.string(),
   messageId: z.string().optional(),
+  model: z
+    .object({
+      providerID: z.string(),
+      modelID: z.string(),
+    })
+    .optional(),
 })
 export type UserInputPayload = z.infer<typeof UserInputPayloadSchema>
 
@@ -147,6 +153,7 @@ export type CollabPayload =
   | { kind: "child_waiting"; data: ChildWaitingPayload }
   | { kind: "child_progress"; data: ChildProgressPayload }
   | { kind: "remote_task_terminal"; data: RemoteTaskTerminalPayload }
+  | { kind: "session_remote_task_terminal"; data: RemoteTaskTerminalPayload }
   | { kind: "cancel"; data: CancelPayload }
   | { kind: "user_input"; data: UserInputPayload }
   | { kind: "system"; data: SystemPayload }

--- a/packages/opencode/src/project/bootstrap.ts
+++ b/packages/opencode/src/project/bootstrap.ts
@@ -34,9 +34,13 @@ export async function InstanceBootstrap() {
   // mounts CollabProgressHook / CollabAutoWake synchronously up front, then
   // kicks off each zombie's loop in the background — run it detached so a slow
   // per-agent restart doesn't stall project bootstrap.
-  void CollabRecovery.scan().catch((err) => {
-    Log.Default.error("collab recovery failed", { error: err })
-  })
+  const { ExperimentAgent } = await import("../research/experiment-agent")
+  ExperimentAgent.ensure()
+  void CollabRecovery.scan()
+    .then(() => ExperimentAgent.scan())
+    .catch((err) => {
+      Log.Default.error("collab recovery failed", { error: err })
+    })
 
   Bus.subscribe(Command.Event.Executed, async (payload) => {
     if (payload.properties.name === Command.Default.INIT) {

--- a/packages/opencode/src/research/experiment-agent.ts
+++ b/packages/opencode/src/research/experiment-agent.ts
@@ -1,0 +1,308 @@
+import { eq } from "drizzle-orm"
+
+import { Bus } from "@/bus"
+import { CollabAgentNode } from "@/collab/agent-node"
+import { CollabEvent } from "@/collab/events"
+import { CollabMessage } from "@/collab/message"
+import { CollabRuntime } from "@/collab/runtime"
+import { Identifier } from "@/id/id"
+import { Instance } from "@/project/instance"
+import { SessionStatus } from "@/session/status"
+import { SessionTable } from "@/session/session.sql"
+import { SessionOwnership } from "@/session/ownership"
+import { Database } from "@/storage/db"
+import { Log } from "@/util/log"
+import { ExperimentRemoteTaskListener } from "./experiment-remote-task-listener"
+import { AtomTable, ExperimentTable, ResearchProjectTable } from "./research.sql"
+
+export namespace ExperimentAgent {
+  const log = Log.create({ service: "experiment-agent" })
+
+  export type Result = {
+    status: "attached" | "deferred" | "unbound" | "conflict"
+    agentId?: string
+    reason?: string
+  }
+
+  export class BusyError extends Error {
+    constructor(public readonly sessionID: string) {
+      super(`Experiment session ${sessionID} is controlled by its Atom agent`)
+    }
+  }
+
+  const state = Instance.state(
+    () => {
+      const retry = (sessionID: string) => {
+        const exp = Database.use((db) =>
+          db
+            .select({ exp_id: ExperimentTable.exp_id })
+            .from(ExperimentTable)
+            .where(eq(ExperimentTable.exp_session_id, sessionID))
+            .get(),
+        )
+        if (!exp) return
+        void attach(exp.exp_id).catch((err) => log.warn("retry failed", { expId: exp.exp_id, error: String(err) }))
+      }
+      const idle = Bus.subscribe(SessionStatus.Event.Idle, (event) => retry(event.properties.sessionID))
+      const drive = Bus.subscribe(CollabEvent.RootDriveEnded, (event) => retry(event.properties.sessionID))
+      const status = Bus.subscribe(CollabEvent.AgentStatus, (event) => {
+        const node = CollabAgentNode.tryLoad(event.properties.agentId)
+        if (node) setTimeout(() => retry(node.session_id), 0)
+      })
+      return { idle, drive, status }
+    },
+    async (value) => {
+      value.idle()
+      value.drive()
+      value.status()
+    },
+  )
+  const tasks = Instance.state(() => new Map<string, Promise<Result>>())
+
+  export function ensure() {
+    state()
+  }
+
+  export async function scan() {
+    ensure()
+    const exps = Database.use((db) =>
+      db
+        .select({ id: ExperimentTable.exp_id })
+        .from(ExperimentTable)
+        .innerJoin(
+          ResearchProjectTable,
+          eq(ResearchProjectTable.research_project_id, ExperimentTable.research_project_id),
+        )
+        .where(eq(ResearchProjectTable.project_id, Instance.project.id))
+        .all(),
+    )
+    await Promise.all(exps.map((exp) => attach(exp.id)))
+  }
+
+  export async function atom(atomId: string) {
+    ensure()
+    const exps = Database.use((db) =>
+      db.select({ id: ExperimentTable.exp_id }).from(ExperimentTable).where(eq(ExperimentTable.atom_id, atomId)).all(),
+    )
+    return Promise.all(exps.map((exp) => attach(exp.id)))
+  }
+
+  export function attach(expId: string, opts?: { force?: boolean }): Promise<Result> {
+    ensure()
+    const key = opts?.force ? `${expId}:force` : expId
+    const current = tasks().get(key)
+    if (current) return current
+    const task = run(expId, opts?.force === true).finally(() => {
+      if (tasks().get(key) === task) tasks().delete(key)
+    })
+    tasks().set(key, task)
+    return task
+  }
+
+  export async function recover(agentId: string) {
+    const node = CollabAgentNode.tryLoad(agentId)
+    const expId = node?.spec.metadata?.expId
+    if (typeof expId !== "string") return node
+    const result = await attach(expId, { force: true })
+    if (!result.agentId) return node
+    return CollabAgentNode.load(result.agentId)
+  }
+
+  async function run(expId: string, force: boolean): Promise<Result> {
+    const exp = Database.use((db) => db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_id, expId)).get())
+    if (!exp?.atom_id) return { status: "unbound", reason: "Experiment is not linked to an atom" }
+    const research = Database.use((db) =>
+      db
+        .select({ project: ResearchProjectTable.project_id })
+        .from(ResearchProjectTable)
+        .where(eq(ResearchProjectTable.research_project_id, exp.research_project_id))
+        .get(),
+    )
+    if (research?.project !== Instance.project.id) {
+      return { status: "conflict", reason: "Experiment project mismatch" }
+    }
+
+    const current = exp.exp_session_id
+      ? Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, exp.exp_session_id!)).get())
+      : undefined
+    const previous = exp.exp_session_id ? CollabAgentNode.loadBySessionId(exp.exp_session_id) : undefined
+    if (!current && previous && !force && !(await settled(previous.id))) {
+      return { status: "deferred", agentId: previous.id, reason: "Archived experiment agent is still active" }
+    }
+    if (current?.time_archived) {
+      await import("@/session").then((mod) => mod.Session.setArchived({ sessionID: current.id }))
+    }
+    const created =
+      !current
+        ? await import("@/session").then((mod) => mod.Session.create({ title: `Exp: ${exp.exp_name}` }))
+        : undefined
+    if (created) {
+      Database.transaction((db) => {
+        db
+          .update(ExperimentTable)
+          .set({ exp_session_id: created.id, time_updated: Date.now() })
+          .where(eq(ExperimentTable.exp_id, expId))
+          .run()
+        if (previous) CollabAgentNode.rebind(previous.id, created.id)
+      })
+    }
+    const sessionId = created?.id ?? exp.exp_session_id
+    if (!sessionId) return { status: "unbound", reason: "Experiment has no session" }
+
+    const session = Database.use((db) => db.select().from(SessionTable).where(eq(SessionTable.id, sessionId)).get())
+    if (!session) return { status: "unbound", reason: "Experiment session is unavailable" }
+
+    const atomId = exp.atom_id
+    const atom = Database.use((db) => db.select().from(AtomTable).where(eq(AtomTable.atom_id, atomId)).get())
+    if (!atom?.session_id) return { status: "unbound", reason: "Atom has no session" }
+    if (atom.research_project_id !== exp.research_project_id) {
+      return { status: "conflict", reason: "Experiment atom project mismatch" }
+    }
+
+    const parent = Database.use((db) =>
+      db.select().from(SessionTable).where(eq(SessionTable.id, atom.session_id!)).get(),
+    )
+    if (!parent || parent.time_archived) return { status: "unbound", reason: "Atom session is unavailable" }
+    if (parent.project_id !== Instance.project.id)
+      return { status: "conflict", reason: "Atom session project mismatch" }
+    if (session.project_id !== parent.project_id) {
+      return { status: "conflict", reason: "Experiment session project mismatch" }
+    }
+
+    let root = await import("@/collab").then((mod) =>
+      mod.Collab.ensureRootFromSession(parent.id, {
+        name: `Atom: ${atom.atom_name}`,
+        subagentType: "research",
+        spec: { initialPrompt: "", policy: { on_fail: "continue" }, metadata: { atomId: atom.atom_id } },
+      }),
+    )
+    root = CollabAgentNode.spec(root.id, {
+      ...root.spec,
+      policy: { ...root.spec.policy, on_fail: "continue" },
+      metadata: { ...root.spec.metadata, atomId: atom.atom_id },
+    })
+    if (!CollabAgentNode.isActive(root.status)) root = CollabAgentNode.activate(root.id)
+    const node = previous ?? CollabAgentNode.loadBySessionId(session.id)
+    if (!node) {
+      const info = CollabAgentNode.create({
+        id: Identifier.ascending("collab_agent"),
+        sessionId: session.id,
+        parentAgentId: root.id,
+        name: `Experiment: ${exp.exp_name}`,
+        projectId: session.project_id,
+        rootAgentId: root.root_agent_id,
+        subagentType: "experiment",
+        spec: { initialPrompt: "", policy: { on_fail: "continue" }, metadata: { expId, atomId: atom.atom_id } },
+        status: "idle",
+      })
+      return { status: "attached", agentId: info.id }
+    }
+
+    const metadata = node.spec.metadata
+    if (node.parent_agent_id && (metadata?.expId !== expId || metadata.atomId !== atomId)) {
+      return { status: "conflict", agentId: node.id, reason: `Experiment agent belongs to ${node.parent_agent_id}` }
+    }
+    CollabAgentNode.spec(node.id, {
+      ...node.spec,
+      policy: { ...node.spec.policy, on_fail: "continue" },
+      metadata: { ...node.spec.metadata, expId, atomId },
+    })
+    if (node.parent_agent_id === root.id && node.root_agent_id === root.root_agent_id) {
+      CollabAgentNode.recomputeActiveChildren(root.id)
+      return { status: "attached", agentId: node.id }
+    }
+    const ready = await settled(node.id)
+    if (
+      !ready &&
+      (!force ||
+        CollabRuntime.has(node.id) ||
+        SessionStatus.get(node.session_id).type !== "idle" ||
+        !SessionOwnership.available(node.session_id, "collab"))
+    ) {
+      return { status: "deferred", agentId: node.id, reason: "Existing Collab tree is active" }
+    }
+
+    const info = CollabAgentNode.attach({
+      id: node.id,
+      parentId: root.id,
+      rootId: root.root_agent_id,
+      name: `Experiment: ${exp.exp_name}`,
+      subagentType: "experiment",
+      metadata: { expId, atomId: atom.atom_id },
+    })
+    CollabAgentNode.recomputeActiveChildren(root.id)
+    return { status: "attached", agentId: info.id }
+  }
+
+  export function get(expId: string) {
+    const exp = Database.use((db) =>
+      db
+        .select({ session: ExperimentTable.exp_session_id })
+        .from(ExperimentTable)
+        .where(eq(ExperimentTable.exp_id, expId))
+        .get(),
+    )
+    if (!exp?.session) return
+    return CollabAgentNode.loadBySessionId(exp.session)
+  }
+
+  export function assertHuman(sessionID: string) {
+    const exp = Database.use((db) =>
+      db
+        .select({ id: ExperimentTable.exp_id })
+        .from(ExperimentTable)
+        .where(eq(ExperimentTable.exp_session_id, sessionID))
+        .get(),
+    )
+    if (!exp) return
+    const node = CollabAgentNode.loadBySessionId(sessionID)
+    if (!node?.parent_agent_id || !CollabAgentNode.isActive(node.status)) return
+    throw new BusyError(sessionID)
+  }
+
+  export function claimHuman(sessionID: string) {
+    assertHuman(sessionID)
+    const release = SessionOwnership.claim(sessionID, "human")
+    if (!release) throw new BusyError(sessionID)
+    return release
+  }
+
+  async function settled(agentId: string) {
+    const node = CollabAgentNode.load(agentId)
+    if (node.parent_agent_id && CollabAgentNode.isActive(node.status)) return false
+    if (SessionStatus.get(node.session_id).type !== "idle") return false
+    const { CollabAutoWake } = await import("@/collab/auto-wake")
+    if (CollabAutoWake.isDriving(node.session_id)) return false
+    if (
+      node.active_children > 0 ||
+      CollabMessage.hasPendingWakeMsg(node.id) ||
+      CollabMessage.hasPendingKind(node.id, "session_remote_task_terminal")
+    )
+      return false
+    return branch(node.id).every((item) => {
+      if (
+        CollabRuntime.has(item.id) ||
+        ExperimentRemoteTaskListener.has(item.id) ||
+        CollabMessage.hasPendingKind(item.id, "session_remote_task_terminal")
+      )
+        return false
+      return item.id === node.id || !CollabAgentNode.isActive(item.status)
+    })
+  }
+
+  function branch(agentId: string) {
+    const node = CollabAgentNode.load(agentId)
+    const tree = CollabAgentNode.loadTree(node.root_agent_id)
+    const ids = new Set([node.id])
+    let changed = true
+    while (changed) {
+      changed = false
+      for (const item of tree) {
+        if (!item.parent_agent_id || !ids.has(item.parent_agent_id) || ids.has(item.id)) continue
+        ids.add(item.id)
+        changed = true
+      }
+    }
+    return tree.filter((item) => ids.has(item.id))
+  }
+}

--- a/packages/opencode/src/research/experiment-remote-task-listener.ts
+++ b/packages/opencode/src/research/experiment-remote-task-listener.ts
@@ -9,7 +9,7 @@ type Task = typeof RemoteTaskTable.$inferSelect
 const terminal = new Set<Task["status"]>(["finished", "failed", "crashed", "canceled"])
 
 export namespace ExperimentRemoteTaskListener {
-  export function register(input: { taskId: string; agentId: string }) {
+  export function register(input: { taskId: string; agentId: string; mode: "direct" | "collab" }) {
     return Database.transaction((tx) => {
       const task = tx.select().from(RemoteTaskTable).where(eq(RemoteTaskTable.task_id, input.taskId)).get()
       if (!task) throw new Error(`remote task not found: ${input.taskId}`)
@@ -29,18 +29,28 @@ export namespace ExperimentRemoteTaskListener {
 
       const now = Date.now()
       tx.insert(RemoteTaskListenerTable)
-        .values({ task_id: input.taskId, agent_id: input.agentId, time_created: now, time_updated: now })
+        .values({
+          task_id: input.taskId,
+          agent_id: input.agentId,
+          mode: input.mode,
+          time_created: now,
+          time_updated: now,
+        })
         .run()
       return { listening: true as const, duplicate: false, task }
     })
   }
 
-  export function has(agentId: string) {
+  export function has(agentId: string, mode?: "direct" | "collab") {
     return Database.use((db) =>
       db
         .select({ task_id: RemoteTaskListenerTable.task_id })
         .from(RemoteTaskListenerTable)
-        .where(eq(RemoteTaskListenerTable.agent_id, agentId))
+        .where(
+          mode
+            ? and(eq(RemoteTaskListenerTable.agent_id, agentId), eq(RemoteTaskListenerTable.mode, mode))
+            : eq(RemoteTaskListenerTable.agent_id, agentId),
+        )
         .limit(1)
         .get(),
     )
@@ -64,7 +74,7 @@ export namespace ExperimentRemoteTaskListener {
       CollabMessage.post({
         recipientAgentId: listener.agent_id,
         senderAgentId: null,
-        kind: "remote_task_terminal",
+        kind: listener.mode === "direct" ? "session_remote_task_terminal" : "remote_task_terminal",
         payload,
       })
       Database.use((db) =>

--- a/packages/opencode/src/research/remote-task-listener.sql.ts
+++ b/packages/opencode/src/research/remote-task-listener.sql.ts
@@ -12,6 +12,7 @@ export const RemoteTaskListenerTable = sqliteTable(
     agent_id: text()
       .notNull()
       .references(() => CollabAgentTable.id, { onDelete: "cascade" }),
+    mode: text().$type<"direct" | "collab">().notNull().default("collab"),
     ...Timestamps,
   },
   (table) => [

--- a/packages/opencode/src/server/routes/collab.ts
+++ b/packages/opencode/src/server/routes/collab.ts
@@ -91,9 +91,9 @@ export const CollabRoutes = new Hono()
   .get(
     "/peer-sessions",
     describeRoute({
-      summary: "List session ids of all Collab peer agents (non-root) in current project",
+      summary: "List session ids of spawned Collab peer agents in current project",
       description:
-        "Returns the set of session ids that belong to peer (non-root) Collab agents. Used by the UI sidebar to hide peer sessions from the flat session list — they are only ever reached via the parent agent's dock.",
+        "Returns session ids explicitly marked as spawned Collab peers. Domain-owned Atom and Experiment sessions remain visible in the research tree.",
       operationId: "collab.peerSessions.list",
       responses: {
         200: {

--- a/packages/opencode/src/server/routes/remote.ts
+++ b/packages/opencode/src/server/routes/remote.ts
@@ -99,7 +99,8 @@ function auth(token: string) {
     const value = header || query || cookie
     if (value !== token) return c.text("Unauthorized", 401)
     c.req.raw.headers.set("x-opencode-remote-authenticated", "true")
-    if (query === token) c.header("Set-Cookie", `${COOKIE}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax`)
+    if (query === token)
+      c.header("Set-Cookie", `${COOKIE}=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax`)
     await next()
   }
 }
@@ -894,15 +895,22 @@ function createRemoteRoutes(opts: { expose: boolean }): Hono {
             return Instance.provide({
               directory: session.directory,
               async fn() {
+                let release: (() => void) | undefined
                 try {
+                  release = await import("@/research/experiment-agent").then((mod) =>
+                    mod.ExperimentAgent.claimHuman(sessionID),
+                  )
                   SessionPrompt.assertNotBusy(sessionID)
                 } catch (err) {
+                  release?.()
                   return { sessionID, ok: false, message: message(err) }
                 }
                 void SessionPrompt.prompt({
                   sessionID,
                   parts: [{ type: "text", text: body.text }],
-                }).catch(() => undefined)
+                })
+                  .catch(() => undefined)
+                  .finally(release)
                 return { sessionID, ok: true, message: "accepted" }
               },
             })

--- a/packages/opencode/src/server/routes/research.ts
+++ b/packages/opencode/src/server/routes/research.ts
@@ -474,7 +474,7 @@ export const ResearchRoutes = new Hono()
           .where(eq(ResearchProjectTable.research_project_id, researchProjectId))
           .get(),
       )
-      if (!project) {
+      if (!project || project.project_id !== Instance.project.id) {
         return c.json({ success: false, message: `research project not found: ${researchProjectId}` }, 404)
       }
 
@@ -1364,10 +1364,21 @@ export const ResearchRoutes = new Hono()
       if (!atom) {
         return c.json({ success: false, message: `atom not found: ${atomId}` }, 404)
       }
+      const project = Database.use((db) =>
+        db
+          .select({ id: ResearchProjectTable.project_id })
+          .from(ResearchProjectTable)
+          .where(eq(ResearchProjectTable.research_project_id, atom.research_project_id))
+          .get(),
+      )
+      if (project?.id !== Instance.project.id) {
+        return c.json({ success: false, message: `atom not found: ${atomId}` }, 404)
+      }
 
       if (atom.session_id) {
         const existing = await Session.get(atom.session_id).catch(() => undefined)
         if (existing && !existing.time.archived) {
+          await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.atom(atomId))
           return c.json({ session_id: atom.session_id, created: false })
         }
       }
@@ -1381,6 +1392,8 @@ export const ResearchRoutes = new Hono()
           .where(eq(AtomTable.atom_id, atomId))
           .run(),
       )
+
+      await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.atom(atomId))
 
       return c.json({ session_id: session.id, created: true })
     },
@@ -1838,6 +1851,16 @@ export const ResearchRoutes = new Hono()
       if (!atom) {
         return c.json({ success: false, message: `atom not found: ${body.atomId}` }, 404)
       }
+      const project = Database.use((db) =>
+        db
+          .select({ id: ResearchProjectTable.project_id })
+          .from(ResearchProjectTable)
+          .where(eq(ResearchProjectTable.research_project_id, atom.research_project_id))
+          .get(),
+      )
+      if (project?.id !== Instance.project.id) {
+        return c.json({ success: false, message: `atom not found: ${body.atomId}` }, 404)
+      }
       const expId = uniqueID()
       const session = await Session.create({ title: `Exp: ${body.expName}` })
 
@@ -1906,6 +1929,8 @@ export const ResearchRoutes = new Hono()
       )
 
       ExperimentExecutionWatch.createOrGet(expId, `${body.expName} for ${atom.atom_name}`, "pending")
+      await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.attach(expId))
+      Bus.publish(Research.Event.AtomsUpdated, { researchProjectId: atom.research_project_id })
 
       return c.json({
         exp_id: expId,
@@ -1954,25 +1979,37 @@ export const ResearchRoutes = new Hono()
       if (!experiment) {
         return c.json({ success: false, message: `experiment not found: ${expId}` }, 404)
       }
+      const project = Database.use((db) =>
+        db
+          .select({ id: ResearchProjectTable.project_id })
+          .from(ResearchProjectTable)
+          .where(eq(ResearchProjectTable.research_project_id, experiment.research_project_id))
+          .get(),
+      )
+      if (project?.id !== Instance.project.id) {
+        return c.json({ success: false, message: `experiment not found: ${expId}` }, 404)
+      }
 
       if (experiment.exp_session_id) {
         const existing = await Session.get(experiment.exp_session_id).catch(() => undefined)
         if (existing && !existing.time.archived) {
+          await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.attach(expId))
           return c.json({ session_id: experiment.exp_session_id, created: false })
         }
       }
 
-      const session = await Session.create({ title: `Exp: ${experiment.exp_name}` })
-
-      Database.use((db) =>
-        db
-          .update(ExperimentTable)
-          .set({ exp_session_id: session.id, time_updated: Date.now() })
-          .where(eq(ExperimentTable.exp_id, expId))
-          .run(),
+      const attached = await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.attach(expId))
+      const updated = Database.use((db) =>
+        db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_id, expId)).get(),
       )
-
-      return c.json({ session_id: session.id, created: true })
+      if (!updated?.exp_session_id) {
+        return c.json({ success: false, message: `failed to create session for experiment: ${expId}` }, 404)
+      }
+      const ready = await Session.get(updated.exp_session_id).catch(() => undefined)
+      if (!ready || ready.time.archived) {
+        return c.json({ success: false, message: attached.reason ?? `experiment session is unavailable: ${expId}` }, 400)
+      }
+      return c.json({ session_id: updated.exp_session_id, created: updated.exp_session_id !== experiment.exp_session_id })
     },
   )
   .post(

--- a/packages/opencode/src/server/routes/session.ts
+++ b/packages/opencode/src/server/routes/session.ts
@@ -350,9 +350,16 @@ export const SessionRoutes = lazy(() =>
       validator("json", Session.initialize.schema.omit({ sessionID: true })),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
+        const release = await import("@/research/experiment-agent").then((mod) =>
+          mod.ExperimentAgent.claimHuman(sessionID),
+        )
         const body = c.req.valid("json")
-        await Session.initialize({ ...body, sessionID })
-        return c.json(true)
+        try {
+          await Session.initialize({ ...body, sessionID })
+          return c.json(true)
+        } finally {
+          release()
+        }
       },
     )
     .post(
@@ -411,7 +418,9 @@ export const SessionRoutes = lazy(() =>
         }),
       ),
       async (c) => {
-        SessionPrompt.cancel(c.req.valid("param").sessionID)
+        const sessionID = c.req.valid("param").sessionID
+        await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.assertHuman(sessionID))
+        SessionPrompt.cancel(sessionID)
         return c.json(true)
       },
     )
@@ -550,29 +559,36 @@ export const SessionRoutes = lazy(() =>
       ),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
+        const release = await import("@/research/experiment-agent").then((mod) =>
+          mod.ExperimentAgent.claimHuman(sessionID),
+        )
         const body = c.req.valid("json")
-        const session = await Session.get(sessionID)
-        await SessionRevert.cleanup(session)
-        const msgs = await Session.messages({ sessionID })
-        let currentAgent = await Agent.defaultAgent()
-        for (let i = msgs.length - 1; i >= 0; i--) {
-          const info = msgs[i].info
-          if (info.role === "user") {
-            currentAgent = info.agent || (await Agent.defaultAgent())
-            break
+        try {
+          const session = await Session.get(sessionID)
+          await SessionRevert.cleanup(session)
+          const msgs = await Session.messages({ sessionID })
+          let currentAgent = await Agent.defaultAgent()
+          for (let i = msgs.length - 1; i >= 0; i--) {
+            const info = msgs[i].info
+            if (info.role === "user") {
+              currentAgent = info.agent || (await Agent.defaultAgent())
+              break
+            }
           }
+          await SessionCompaction.create({
+            sessionID,
+            agent: currentAgent,
+            model: {
+              providerID: body.providerID,
+              modelID: body.modelID,
+            },
+            auto: body.auto,
+          })
+          await SessionPrompt.loop({ sessionID })
+          return c.json(true)
+        } finally {
+          release()
         }
-        await SessionCompaction.create({
-          sessionID,
-          agent: currentAgent,
-          model: {
-            providerID: body.providerID,
-            modelID: body.modelID,
-          },
-          auto: body.auto,
-        })
-        await SessionPrompt.loop({ sessionID })
-        return c.json(true)
       },
     )
     .get(
@@ -793,13 +809,20 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const release = await import("@/research/experiment-agent").then((mod) =>
+          mod.ExperimentAgent.claimHuman(sessionID),
+        )
         c.status(200)
         c.header("Content-Type", "application/json")
         return stream(c, async (stream) => {
-          const sessionID = c.req.valid("param").sessionID
-          const body = c.req.valid("json")
-          const msg = await SessionPrompt.prompt({ ...body, sessionID })
-          stream.write(JSON.stringify(msg))
+          try {
+            const body = c.req.valid("json")
+            const msg = await SessionPrompt.prompt({ ...body, sessionID })
+            stream.write(JSON.stringify(msg))
+          } finally {
+            release()
+          }
         })
       },
     )
@@ -825,12 +848,15 @@ export const SessionRoutes = lazy(() =>
       ),
       validator("json", SessionPrompt.PromptInput.omit({ sessionID: true })),
       async (c) => {
+        const sessionID = c.req.valid("param").sessionID
+        const release = await import("@/research/experiment-agent").then((mod) =>
+          mod.ExperimentAgent.claimHuman(sessionID),
+        )
         c.status(204)
         c.header("Content-Type", "application/json")
         return stream(c, async () => {
-          const sessionID = c.req.valid("param").sessionID
           const body = c.req.valid("json")
-          SessionPrompt.prompt({ ...body, sessionID })
+          void SessionPrompt.prompt({ ...body, sessionID }).finally(release)
         })
       },
     )
@@ -866,9 +892,15 @@ export const SessionRoutes = lazy(() =>
       validator("json", SessionPrompt.CommandInput.omit({ sessionID: true })),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
+        const release = await import("@/research/experiment-agent").then((mod) =>
+          mod.ExperimentAgent.claimHuman(sessionID),
+        )
         const body = c.req.valid("json")
-        const msg = await SessionPrompt.command({ ...body, sessionID })
-        return c.json(msg)
+        try {
+          return c.json(await SessionPrompt.command({ ...body, sessionID }))
+        } finally {
+          release()
+        }
       },
     )
     .post(
@@ -898,9 +930,15 @@ export const SessionRoutes = lazy(() =>
       validator("json", SessionPrompt.ShellInput.omit({ sessionID: true })),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
+        const release = await import("@/research/experiment-agent").then((mod) =>
+          mod.ExperimentAgent.claimHuman(sessionID),
+        )
         const body = c.req.valid("json")
-        const msg = await SessionPrompt.shell({ ...body, sessionID })
-        return c.json(msg)
+        try {
+          return c.json(await SessionPrompt.shell({ ...body, sessionID }))
+        } finally {
+          release()
+        }
       },
     )
     .post(
@@ -930,9 +968,15 @@ export const SessionRoutes = lazy(() =>
       validator("json", SessionPrompt.RemoteTaskInput.omit({ sessionID: true })),
       async (c) => {
         const sessionID = c.req.valid("param").sessionID
+        const release = await import("@/research/experiment-agent").then((mod) =>
+          mod.ExperimentAgent.claimHuman(sessionID),
+        )
         const body = c.req.valid("json")
-        const msg = await SessionPrompt.remoteTask({ ...body, sessionID })
-        return c.json(msg)
+        try {
+          return c.json(await SessionPrompt.remoteTask({ ...body, sessionID }))
+        } finally {
+          release()
+        }
       },
     )
     .post(

--- a/packages/opencode/src/session/experiment-workspace.ts
+++ b/packages/opencode/src/session/experiment-workspace.ts
@@ -12,21 +12,28 @@ function root(sessionID: string): string {
 }
 
 export namespace ExperimentWorkspace {
-  export function prompt(sessionID: string) {
+  export function resolve(sessionID: string) {
     const parent = root(sessionID)
     const direct = Database.use((db) =>
       db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_session_id, parent)).get(),
     )
-    const node = direct ? undefined : CollabAgentNode.loadBySessionId(sessionID)
-    const agent = node ? CollabAgentNode.tryLoad(node.root_agent_id) : undefined
-    const ancestor = agent ? root(agent.session_id) : undefined
-    const experiment =
-      direct ??
-      (ancestor
-        ? Database.use((db) =>
-            db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_session_id, ancestor)).get(),
-          )
-        : undefined)
+    if (direct) return direct
+
+    const seen = new Set<string>()
+    let node = CollabAgentNode.loadBySessionId(parent)
+    while (node && !seen.has(node.id)) {
+      seen.add(node.id)
+      const ancestor = root(node.session_id)
+      const experiment = Database.use((db) =>
+        db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_session_id, ancestor)).get(),
+      )
+      if (experiment) return experiment
+      node = node.parent_agent_id ? CollabAgentNode.tryLoad(node.parent_agent_id) : undefined
+    }
+  }
+
+  export function prompt(sessionID: string) {
+    const experiment = resolve(sessionID)
     if (!experiment) return
     return `<experiment-workspace code_path=${JSON.stringify(experiment.code_path)}>Use code_path for experiment code operations. Other workspace files may be read for context.</experiment-workspace>`
   }

--- a/packages/opencode/src/session/index.ts
+++ b/packages/opencode/src/session/index.ts
@@ -399,13 +399,13 @@ export namespace Session {
   export const setArchived = fn(
     z.object({
       sessionID: Identifier.schema("session"),
-      time: z.number().optional(),
+      time: z.number().nullable().optional(),
     }),
     async (input) => {
       return Database.use((db) => {
         const row = db
           .update(SessionTable)
-          .set({ time_archived: input.time })
+          .set({ time_archived: input.time ?? null })
           .where(eq(SessionTable.id, input.sessionID))
           .returning()
           .get()
@@ -660,12 +660,45 @@ export namespace Session {
     return rows.map(fromRow)
   })
 
-  export const remove = fn(Identifier.schema("session"), async (sessionID) => {
+  export const remove = fn(Identifier.schema("session"), async (sessionID) => removeNext(sessionID, new Set()))
+
+  async function removeNext(sessionID: string, removing: Set<string>) {
     const project = Instance.project
     try {
+      if (removing.has(sessionID)) return
+      removing.add(sessionID)
       const session = await get(sessionID)
       for (const child of await children(sessionID)) {
-        await remove(child.id)
+        await removeNext(child.id, removing)
+      }
+      const { CollabAgentNode } = await import("@/collab/agent-node")
+      const agent = CollabAgentNode.loadBySessionId(sessionID)
+      if (agent) {
+        for (const child of CollabAgentNode.loadChildren(agent.id)) {
+          const info = await get(child.session_id).catch(() => undefined)
+          if (info?.collabPeer) {
+            await removeNext(child.session_id, removing)
+            continue
+          }
+          CollabAgentNode.detach(child.id)
+        }
+        const parent = agent.parent_agent_id ? CollabAgentNode.tryLoad(agent.parent_agent_id) : undefined
+        const report = !!parent && CollabAgentNode.isActive(agent.status) && !removing.has(parent.session_id)
+        if (report) {
+          const { CollabMessage } = await import("@/collab/message")
+          await CollabMessage.post({
+            recipientAgentId: parent.id,
+            senderAgentId: agent.id,
+            kind: "child_failed",
+            payload: {
+              childAgentId: agent.id,
+              childName: agent.name,
+              reason: "canceled",
+              message: "Agent session was deleted",
+            },
+          })
+        }
+        CollabAgentNode.drop(agent.id, report)
       }
       await unshare(sessionID).catch(() => {})
       // CASCADE delete handles messages and parts automatically
@@ -680,7 +713,7 @@ export namespace Session {
     } catch (e) {
       log.error(e)
     }
-  })
+  }
 
   export const updateMessage = fn(MessageV2.Info, async (msg) => {
     const time_created = msg.time.created

--- a/packages/opencode/src/session/ownership.ts
+++ b/packages/opencode/src/session/ownership.ts
@@ -1,0 +1,36 @@
+import { Instance } from "@/project/instance"
+
+export namespace SessionOwnership {
+  export type Owner = "human" | "collab"
+  type Entry = { owner: Owner; count: number }
+
+  const state = Instance.state(() => new Map<string, Entry>())
+
+  export function available(sessionID: string, owner: Owner) {
+    const current = state().get(sessionID)
+    return !current || current.owner === owner
+  }
+
+  export function current(sessionID: string) {
+    return state().get(sessionID)?.owner
+  }
+
+  export function claim(sessionID: string, owner: Owner) {
+    if (!available(sessionID, owner)) return
+    const owners = state()
+    const current = owners.get(sessionID)
+    owners.set(sessionID, { owner, count: (current?.count ?? 0) + 1 })
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      const next = owners.get(sessionID)
+      if (!next || next.owner !== owner) return
+      if (next.count === 1) {
+        owners.delete(sessionID)
+        return
+      }
+      owners.set(sessionID, { ...next, count: next.count - 1 })
+    }
+  }
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -81,6 +81,12 @@ const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested struc
 export namespace SessionPrompt {
   const log = Log.create({ service: "session.prompt" })
 
+  export class ModelUnavailableError extends Error {
+    constructor() {
+      super("No available model can resume this session. The agent remains recoverable and can be resumed later.")
+    }
+  }
+
   const state = Instance.state(
     () => {
       const data: Record<
@@ -876,11 +882,50 @@ export namespace SessionPrompt {
     throw new Error("Impossible")
   })
 
-  async function lastModel(sessionID: string) {
+  async function recentModel(sessionID: string) {
     for await (const item of MessageV2.stream(sessionID)) {
       if (item.info.role === "user" && item.info.model) return item.info.model
     }
-    return Provider.defaultModel()
+  }
+
+  async function lastModel(sessionID: string) {
+    return (await recentModel(sessionID)) ?? Provider.defaultModel()
+  }
+
+  export async function resolveModel(input: {
+    sessionID: string
+    agent: string
+    preferred?: { providerID: string; modelID: string }
+    fallback?: { providerID: string; modelID: string }
+  }) {
+    const agent = await Agent.get(input.agent)
+    const candidates = [input.preferred, agent?.model, await recentModel(input.sessionID), input.fallback]
+    candidates.push(await Provider.defaultModel().catch(() => undefined))
+    const providers = await Provider.list()
+    candidates.push(
+      ...Object.values(providers).flatMap((provider) =>
+        Provider.sort(Object.values(provider.models)).map((model) => ({
+          providerID: model.providerID,
+          modelID: model.id,
+        })),
+      ),
+    )
+
+    const seen = new Set<string>()
+    for (const candidate of candidates) {
+      if (!candidate) continue
+      const key = `${candidate.providerID}/${candidate.modelID}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      const valid = await Provider.getModel(candidate.providerID, candidate.modelID)
+        .then(() => true)
+        .catch((err) => {
+          if (Provider.ModelNotFoundError.isInstance(err)) return false
+          throw err
+        })
+      if (valid) return candidate
+    }
+    throw new ModelUnavailableError()
   }
 
   /** @internal Exported for testing */

--- a/packages/opencode/src/tool/experiment-query.ts
+++ b/packages/opencode/src/tool/experiment-query.ts
@@ -2,10 +2,12 @@ import z from "zod"
 import fs from "fs"
 import path from "path"
 import { Tool } from "./tool"
-import { Database, eq } from "../storage/db"
+import { and, Database, eq } from "../storage/db"
 import { AtomTable, ExperimentTable, RemoteServerTable } from "../research/research.sql"
 import { Research } from "../research/research"
 import { normalizeRemoteServerConfig } from "../research/remote-server"
+import { CollabAgentNode } from "../collab/agent-node"
+import { ExperimentWorkspace } from "../session/experiment-workspace"
 
 type ExpRow = typeof ExperimentTable.$inferSelect
 
@@ -74,12 +76,15 @@ function queryExpWithJoins(expId: string): ExpResult | undefined {
 
 function formatExpResult(r: ExpResult): string {
   const e = r.exp
+  const agent = e.exp_session_id ? CollabAgentNode.loadBySessionId(e.exp_session_id) : undefined
   return [
     `exp_id: ${e.exp_id}`,
     `exp_name: ${e.exp_name}`,
     `research_project_id: ${e.research_project_id}`,
     r.atom_id ? `atom_id: ${r.atom_id}` : `atom_id: (not linked)`,
     e.exp_session_id ? `exp_session_id: ${e.exp_session_id}` : null,
+    agent ? `agent_id: ${agent.id}` : `agent_id: (not attached)`,
+    agent ? `agent_status: ${agent.status}` : null,
     e.baseline_branch_name ? `baseline_branch_name: ${e.baseline_branch_name}` : null,
     e.exp_branch_name ? `exp_branch_name: ${e.exp_branch_name}` : null,
     e.exp_result_path ? `exp_result_path: ${e.exp_result_path}` : null,
@@ -125,13 +130,14 @@ export const ExperimentQueryTool = Tool.define("experiment_query", {
     // Mode 1: query by expId
     if (params.expId) {
       const result = queryExpWithJoins(params.expId)
-      if (!result) {
+      if (!result || result.exp.research_project_id !== researchProjectId) {
         return {
           title: "Not found",
           output: `Experiment not found: ${params.expId}`,
           metadata: { count: 0 },
         }
       }
+      await import("../research/experiment-agent").then((mod) => mod.ExperimentAgent.attach(params.expId!))
       return {
         title: `Experiment: ${result.exp.exp_id}`,
         output: formatExpResult(result),
@@ -141,8 +147,28 @@ export const ExperimentQueryTool = Tool.define("experiment_query", {
 
     // Mode 2: query by atomId
     if (params.atomId) {
+      const atom = Database.use((db) =>
+        db
+          .select({ id: AtomTable.atom_id })
+          .from(AtomTable)
+          .where(and(eq(AtomTable.atom_id, params.atomId!), eq(AtomTable.research_project_id, researchProjectId)))
+          .get(),
+      )
+      if (!atom) {
+        return { title: "Not found", output: `Atom not found: ${params.atomId}`, metadata: { count: 0 } }
+      }
+      await import("../research/experiment-agent").then((mod) => mod.ExperimentAgent.atom(params.atomId!))
       const exps = Database.use((db) =>
-        db.select().from(ExperimentTable).where(eq(ExperimentTable.atom_id, params.atomId!)).all(),
+        db
+          .select()
+          .from(ExperimentTable)
+          .where(
+            and(
+              eq(ExperimentTable.atom_id, params.atomId!),
+              eq(ExperimentTable.research_project_id, researchProjectId),
+            ),
+          )
+          .all(),
       )
       if (exps.length === 0) {
         return {
@@ -161,17 +187,15 @@ export const ExperimentQueryTool = Tool.define("experiment_query", {
     }
 
     // Mode 3: query by current session
-    const parentSessionId = (await Research.getParentSessionId(ctx.sessionID)) ?? ctx.sessionID
-    const exp = Database.use((db) =>
-      db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_session_id, parentSessionId)).get(),
-    )
-    if (!exp) {
+    const exp = ExperimentWorkspace.resolve(ctx.sessionID)
+    if (!exp || exp.research_project_id !== researchProjectId) {
       return {
         title: "No experiment",
         output: "No experiment is linked to the current session.",
         metadata: { count: 0 },
       }
     }
+    await import("../research/experiment-agent").then((mod) => mod.ExperimentAgent.attach(exp.exp_id))
     const result = queryExpWithJoins(exp.exp_id)
     if (!result) {
       return {

--- a/packages/opencode/src/tool/experiment-remote-task.ts
+++ b/packages/opencode/src/tool/experiment-remote-task.ts
@@ -14,6 +14,7 @@ import {
 } from "@/research/remote-task-runner"
 import { normalizeRemoteServerConfig, remoteServerLabel } from "@/research/remote-server"
 import { Database, eq } from "@/storage/db"
+import { SessionOwnership } from "@/session/ownership"
 
 const kind = z.enum(["resource_download", "experiment_run", "env_setup"])
 
@@ -187,7 +188,11 @@ export const ExperimentRemoteTaskGetTool = Tool.define("experiment_remote_task_g
         subagentType: ctx.agent,
         spec: { initialPrompt: "" },
       })
-      const registered = ExperimentRemoteTaskListener.register({ taskId: task.task_id, agentId: node.id })
+      const registered = ExperimentRemoteTaskListener.register({
+        taskId: task.task_id,
+        agentId: node.id,
+        mode: SessionOwnership.current(ctx.sessionID) === "human" ? "direct" : "collab",
+      })
       task = registered.task
       listening = registered.listening
       duplicate = registered.duplicate

--- a/packages/opencode/src/tool/experiment.ts
+++ b/packages/opencode/src/tool/experiment.ts
@@ -10,6 +10,7 @@ import { git } from "../util/git"
 import { ensureRepoInitialized, GIT_ENV } from "../session/experiment-guard"
 import { ExperimentExecutionWatch } from "../research/experiment-execution-watch"
 import { Session } from "@/session"
+import { Bus } from "@/bus"
 
 export const ExperimentCreateTool = Tool.define("experiment_create", {
   description:
@@ -32,7 +33,7 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
       return {
         title: "Failed",
         output: "Current session is not associated with any research project.",
-        metadata: { expId: undefined as string | undefined },
+        metadata: { expId: undefined as string | undefined, agentId: undefined as string | undefined },
       }
     }
 
@@ -41,7 +42,14 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
       return {
         title: "Failed",
         output: `Atom not found: ${params.atomId}`,
-        metadata: { expId: undefined as string | undefined },
+        metadata: { expId: undefined as string | undefined, agentId: undefined as string | undefined },
+      }
+    }
+    if (atom.research_project_id !== researchProjectId) {
+      return {
+        title: "Failed",
+        output: `Atom does not belong to the current research project: ${params.atomId}`,
+        metadata: { expId: undefined as string | undefined, agentId: undefined as string | undefined },
       }
     }
 
@@ -62,7 +70,7 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
       return {
         title: "Failed",
         output: `Failed to initialise repo at ${params.codePath}: ${initResult.message}`,
-        metadata: { expId: undefined as string | undefined },
+        metadata: { expId: undefined as string | undefined, agentId: undefined as string | undefined },
       }
     }
 
@@ -71,7 +79,7 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
       return {
         title: "Failed",
         output: `Baseline branch "${params.baselineBranch}" not found at ${params.codePath}`,
-        metadata: { expId: undefined as string | undefined },
+        metadata: { expId: undefined as string | undefined, agentId: undefined as string | undefined },
       }
     }
 
@@ -84,7 +92,7 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
       return {
         title: "Failed",
         output: `Failed to create worktree for ${expId}: ${createWorktree.stderr?.toString().trim() || "unknown error"}`,
-        metadata: { expId: undefined as string | undefined },
+        metadata: { expId: undefined as string | undefined, agentId: undefined as string | undefined },
       }
     }
 
@@ -113,6 +121,8 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
     )
 
     ExperimentExecutionWatch.createOrGet(expId, `${params.expName} for ${atom.atom_name}`, "pending")
+    const attached = await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.attach(expId))
+    Bus.publish(Research.Event.AtomsUpdated, { researchProjectId })
 
     let remoteServerConfig: string | null = null
     if (params.remoteServerId) {
@@ -129,6 +139,7 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
         `- Experiment ID: ${expId}`,
         `- Atom: ${atom.atom_name} (${atom.atom_id})`,
         `- Session ID: ${session.id}`,
+        attached.agentId ? `- Agent ID: ${attached.agentId}` : null,
         `- Baseline branch: ${params.baselineBranch}`,
         `- Experiment branch: ${expId}`,
         `- Result path: ${expResultPath}`,
@@ -137,7 +148,7 @@ export const ExperimentCreateTool = Tool.define("experiment_create", {
       ]
         .filter(Boolean)
         .join("\n"),
-      metadata: { expId: expId as string | undefined },
+      metadata: { expId: expId as string | undefined, agentId: attached.agentId },
     }
   },
 })

--- a/packages/opencode/src/tool/list-children.txt
+++ b/packages/opencode/src/tool/list-children.txt
@@ -25,7 +25,7 @@ If you need a child's actual output, call `read_agent_output(agent_id)` on that 
 
 For each direct child:
 - `agent_id`, `name`, `subagent_type`
-- `status`: `pending` | `running` | `blocked_on_children` | `completed` | `failed` | `canceled`
+- `status`: `idle` | `pending` | `running` | `blocked_on_children` | `waiting_interaction` | `completed` | `failed` | `canceled`
 - `active_children`: how many grand-children are still running
 - `spawned_at`, `ended_at`
 

--- a/packages/opencode/src/tool/resume-agent.ts
+++ b/packages/opencode/src/tool/resume-agent.ts
@@ -23,7 +23,7 @@ export const ResumeAgentTool = Tool.define("resume_agent", async () => {
         ...(extra?.session_id ? { session_id: extra.session_id } : {}),
       })
 
-      const target = Collab.tryGet(params.agent_id)
+      let target = Collab.tryGet(params.agent_id)
       if (!target) {
         return { title: "resume_agent", metadata: mk(false), output: `No agent ${params.agent_id}` }
       }
@@ -36,7 +36,18 @@ export const ResumeAgentTool = Tool.define("resume_agent", async () => {
           output: "Caller session is not a Collab agent; spawn a peer first.",
         }
       }
+      target =
+        (await import("@/research/experiment-agent").then((mod) => mod.ExperimentAgent.recover(params.agent_id))) ??
+        target
       if (target.root_agent_id !== callerNode.root_agent_id) {
+        const atomId = target.spec.metadata?.atomId
+        if (typeof atomId === "string" && atomId === callerNode.spec.metadata?.atomId) {
+          return {
+            title: "resume_agent",
+            metadata: mk(false, { status: target.status, session_id: target.session_id }),
+            output: `Experiment agent ${params.agent_id} is still finishing reconciliation with its Atom. Retry this same agent; do not spawn a replacement.`,
+          }
+        }
         return {
           title: "resume_agent",
           metadata: mk(false),
@@ -55,7 +66,12 @@ export const ResumeAgentTool = Tool.define("resume_agent", async () => {
       })
 
       try {
-        const info = await Collab.resume({ agentId: params.agent_id, prompt: params.prompt })
+        const current = ctx.extra?.model as { providerID?: string; id?: string } | undefined
+        const info = await Collab.resume({
+          agentId: params.agent_id,
+          prompt: params.prompt,
+          model: current?.providerID && current.id ? { providerID: current.providerID, modelID: current.id } : undefined,
+        })
         return {
           title: "resume_agent",
           metadata: mk(true, { status: info.status, session_id: info.session_id }),

--- a/packages/opencode/src/tool/resume-agent.txt
+++ b/packages/opencode/src/tool/resume-agent.txt
@@ -1,12 +1,12 @@
 Continue a peer agent with a new instruction.
 
-Use this when a peer is running, blocked, waiting for your input (`child_waiting`), or when you want a finished peer to continue working on something. The peer continues in its original session (full history preserved), consumes your prompt as its next user message, and posts `child_done` to your inbox when finished.
+Use this when a peer is idle, running, blocked, waiting for your input (`child_waiting`), or when you want a finished peer to continue working on something. The peer continues in its original session (full history preserved), consumes your prompt as its next user message, and posts `child_done` to your inbox when finished.
 
 Rules:
 - If the target is busy, the instruction is queued and consumed after the current turn finishes.
-- If the target is active but idle, the instruction wakes it for a new turn.
-- Your own collab agent must still be active — you cannot resume a peer from a session that has itself finalized (the result would have no one to route back to).
-- The peer runs with its original agent type / model / policy. If you want a different configuration, `spawn_agent` a new peer instead.
+- If the target is `idle`, the instruction starts a parent-owned turn and wakes it.
+- Experiment agents are always recovered in their original session. A missing or finalized Atom parent is repaired before resume; do not spawn a replacement Experiment agent.
+- The peer keeps its original agent type and history. If its previous model is unavailable, the framework uses the current Atom model and persists that replacement for later turns.
 
 Parameters:
 - agent_id: the target peer's id (get from `child_waiting`, `child_done`, `list_children`, or the session's collab agent record).

--- a/packages/opencode/src/tool/spawn-agent.ts
+++ b/packages/opencode/src/tool/spawn-agent.ts
@@ -1,6 +1,7 @@
 import z from "zod"
 import { Agent } from "@/agent/agent"
 import { Collab } from "@/collab"
+import { CollabAgentNode } from "@/collab/agent-node"
 import { AgentPolicySchema, type AgentSpec } from "@/collab/types"
 import { MessageV2 } from "@/session/message-v2"
 import { PermissionNext } from "@/permission/next"
@@ -57,6 +58,9 @@ export const SpawnAgentTool = Tool.define("spawn_agent", async (ctx) => {
 
       // Make sure the current primary session is a Collab root if it is not yet.
       const parentNode = Collab.getBySession(ctx.sessionID)
+      if (parentNode?.parent_agent_id && !CollabAgentNode.isActive(parentNode.status)) {
+        throw new Error("This experiment agent is inactive. Its Atom parent must call resume_agent before it can spawn peers.")
+      }
       if (!parentNode) {
         await Collab.ensureRootFromSession(ctx.sessionID, {
           name: "root",

--- a/packages/opencode/test/research/experiment-agent.test.ts
+++ b/packages/opencode/test/research/experiment-agent.test.ts
@@ -1,0 +1,751 @@
+import fs from "fs/promises"
+import path from "path"
+
+import { describe, expect, spyOn, test } from "bun:test"
+import { eq } from "drizzle-orm"
+
+import { Collab } from "../../src/collab"
+import { CollabAgentNode } from "../../src/collab/agent-node"
+import { CollabAutoWake } from "../../src/collab/auto-wake"
+import { CollabLoop } from "../../src/collab/loop"
+import { CollabMessage } from "../../src/collab/message"
+import { CollabRuntime } from "../../src/collab/runtime"
+import { Identifier } from "../../src/id/id"
+import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { ExperimentAgent } from "../../src/research/experiment-agent"
+import { ExperimentRemoteTask } from "../../src/research/experiment-remote-task"
+import { ExperimentRemoteTaskListener } from "../../src/research/experiment-remote-task-listener"
+import { AtomTable, ExperimentTable, ResearchProjectTable } from "../../src/research/research.sql"
+import { Session } from "../../src/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionStatus } from "../../src/session/status"
+import { Database } from "../../src/storage/db"
+import { tmpdir } from "../fixture/fixture"
+
+CollabAutoWake.setEnabled(false)
+
+async function seed(input?: { session?: boolean }) {
+  const atom = await Session.create({ title: "Atom: test" })
+  const exp = input?.session === false ? undefined : await Session.create({ title: "Exp: test" })
+  const research = crypto.randomUUID()
+  const atomId = crypto.randomUUID()
+  const expId = crypto.randomUUID()
+  const now = Date.now()
+
+  Database.use((db) =>
+    db
+      .insert(ResearchProjectTable)
+      .values({ research_project_id: research, project_id: Instance.project.id, time_created: now, time_updated: now })
+      .run(),
+  )
+  Database.use((db) =>
+    db
+      .insert(AtomTable)
+      .values({
+        atom_id: atomId,
+        research_project_id: research,
+        atom_name: "test atom",
+        atom_type: "verification",
+        atom_evidence_type: "experiment",
+        atom_evidence_status: "pending",
+        session_id: atom.id,
+        time_created: now,
+        time_updated: now,
+      })
+      .run(),
+  )
+  Database.use((db) =>
+    db
+      .insert(ExperimentTable)
+      .values({
+        exp_id: expId,
+        research_project_id: research,
+        exp_name: "test experiment",
+        atom_id: atomId,
+        exp_session_id: exp?.id,
+        code_path: Instance.directory,
+        time_created: now,
+        time_updated: now,
+      })
+      .run(),
+  )
+  return { atom, exp, atomId, expId }
+}
+
+describe("research.experiment-agent", () => {
+  test("attaches existing experiments as idle children idempotently", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const first = await ExperimentAgent.attach(item.expId)
+        const second = await ExperimentAgent.attach(item.expId)
+        expect(first.status).toBe("attached")
+        expect(second).toEqual(first)
+
+        const child = CollabAgentNode.load(first.agentId!)
+        const parent = CollabAgentNode.load(child.parent_agent_id!)
+        expect(child.session_id).toBe(item.exp!.id)
+        expect(child.status).toBe("idle")
+        expect(child.subagent_type).toBe("experiment")
+        expect(child.root_agent_id).toBe(parent.id)
+        expect(child.spec.metadata).toEqual({ expId: item.expId, atomId: item.atomId })
+        expect(parent.session_id).toBe(item.atom.id)
+        expect(parent.active_children).toBe(0)
+        expect(parent.spawned_total).toBe(1)
+        expect(CollabAgentNode.loadPeerSessionIdsByDirectory(Instance.project.id, Instance.directory)).not.toContain(
+          item.exp!.id,
+        )
+        expect(() => ExperimentAgent.assertHuman(item.exp!.id)).not.toThrow()
+      },
+    })
+  })
+
+  test("delivers human remote task completion without activating the experiment or notifying Atom", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const attached = await ExperimentAgent.attach(item.expId)
+        const child = CollabAgentNode.load(attached.agentId!)
+        const task = ExperimentRemoteTask.create({
+          expId: item.expId,
+          kind: "experiment_run",
+          title: "Train model",
+          server: "{}",
+          remoteRoot: "/tmp",
+          screenName: "train",
+          command: "python train.py",
+        })
+        ExperimentRemoteTaskListener.register({ taskId: task.task_id, agentId: child.id, mode: "direct" })
+
+        await expect(Collab.resume({ agentId: child.id, prompt: "inspect" })).rejects.toThrow("human session")
+        ExperimentRemoteTask.update({ taskId: task.task_id, status: "finished" })
+
+        const parent = CollabAgentNode.load(child.parent_agent_id!)
+        expect(CollabMessage.list(parent.id, { kind: "remote_task_terminal" })).toHaveLength(0)
+        expect(CollabMessage.list(child.id, { kind: "session_remote_task_terminal" })).toHaveLength(1)
+        expect(CollabAgentNode.load(child.id).status).toBe("idle")
+        expect(CollabAgentNode.load(parent.id).active_children).toBe(0)
+        await expect(Collab.resume({ agentId: child.id, prompt: "inspect" })).rejects.toThrow("human session")
+
+        const prompt = spyOn(SessionPrompt, "prompt").mockRejectedValue(new Error("provider unavailable"))
+        CollabAutoWake.setEnabled(true)
+        try {
+          SessionStatus.set(child.session_id, { type: "busy" })
+          await Bun.sleep(20)
+          SessionStatus.set(child.session_id, { type: "idle" })
+          await Bun.sleep(20)
+          expect(prompt).toHaveBeenCalledTimes(1)
+          expect(CollabMessage.hasPendingKind(child.id, "session_remote_task_terminal")).toBe(true)
+        } finally {
+          CollabAutoWake.setEnabled(false)
+          prompt.mockRestore()
+        }
+
+        let turns = 0
+        CollabAutoWake.setDriveTurnOverrideForTesting(async (id) => {
+          turns++
+          CollabMessage.drain(id, "direct")
+        })
+        CollabAutoWake.setEnabled(true)
+        try {
+          SessionStatus.set(child.session_id, { type: "idle" })
+          await Bun.sleep(20)
+          expect(turns).toBe(1)
+          expect(CollabMessage.hasPendingKind(child.id, "session_remote_task_terminal")).toBe(false)
+          expect(CollabAgentNode.load(child.id).status).toBe("idle")
+          expect(CollabMessage.list(parent.id, { kind: "remote_task_terminal" })).toHaveLength(0)
+        } finally {
+          CollabAutoWake.setEnabled(false)
+          CollabAutoWake.setDriveTurnOverrideForTesting(undefined)
+        }
+      },
+    })
+  })
+
+  test("drives a remote task listener in the experiment session directory", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const attached = await ExperimentAgent.attach(item.expId)
+        const child = CollabAgentNode.load(attached.agentId!)
+        const task = ExperimentRemoteTask.create({
+          expId: item.expId,
+          kind: "experiment_run",
+          title: "Train model",
+          server: "{}",
+          remoteRoot: "/tmp",
+          screenName: "train",
+          command: "python train.py",
+        })
+        ExperimentRemoteTaskListener.register({ taskId: task.task_id, agentId: child.id, mode: "direct" })
+
+        const other = path.join(tmp.path, "other")
+        await fs.mkdir(other)
+        let directory: string | undefined
+        CollabAutoWake.setDriveTurnOverrideForTesting(async (id) => {
+          directory = Instance.directory
+          CollabMessage.drain(id, "direct")
+        })
+        CollabAutoWake.setEnabled(true)
+        try {
+          await Instance.provide({
+            directory: other,
+            fn: async () => {
+              CollabAutoWake.ensure()
+              ExperimentRemoteTask.update({ taskId: task.task_id, status: "finished" })
+              await Bun.sleep(20)
+            },
+          })
+          await Bun.sleep(20)
+          expect(directory).toBe(tmp.path)
+          expect(CollabMessage.hasPendingKind(child.id, "session_remote_task_terminal")).toBe(false)
+        } finally {
+          CollabAutoWake.setEnabled(false)
+          CollabAutoWake.setDriveTurnOverrideForTesting(undefined)
+        }
+      },
+    })
+  })
+
+  test("wakes a blocked experiment when another instance detects remote task completion", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const attached = await ExperimentAgent.attach(item.expId)
+        const child = CollabAgentNode.activate(attached.agentId!)
+        const parent = CollabAgentNode.load(child.parent_agent_id!)
+        const task = ExperimentRemoteTask.create({
+          expId: item.expId,
+          kind: "experiment_run",
+          title: "Train model",
+          server: "{}",
+          remoteRoot: "/tmp",
+          screenName: "train",
+          command: "python train.py",
+        })
+        ExperimentRemoteTaskListener.register({ taskId: task.task_id, agentId: child.id, mode: "collab" })
+
+        let directory: string | undefined
+        const prompt = spyOn(SessionPrompt, "prompt").mockImplementation(
+          (async () => {
+            directory = Instance.directory
+            return undefined as never
+          }) as unknown as typeof SessionPrompt.prompt,
+        )
+        const source = path.join(tmp.path, "source-collab")
+        const detector = path.join(tmp.path, "detector-collab")
+        await fs.mkdir(source)
+        await fs.mkdir(detector)
+        let run!: Promise<void>
+        await Instance.provide({
+          directory: source,
+          fn: () => {
+            run = CollabLoop.start(child.id)
+          },
+        })
+        try {
+          for (let i = 0; i < 100 && CollabAgentNode.load(child.id).status !== "blocked_on_children"; i++) {
+            await Bun.sleep(10)
+          }
+          expect(CollabAgentNode.load(child.id).status).toBe("blocked_on_children")
+
+          await Instance.provide({
+            directory: detector,
+            fn: async () => {
+              ExperimentRemoteTask.update({ taskId: task.task_id, status: "finished" })
+            },
+          })
+
+          await run
+          expect(directory).toBe(tmp.path)
+          expect(prompt).toHaveBeenCalledTimes(1)
+          expect(CollabAgentNode.load(child.id).status).toBe("completed")
+          expect(CollabMessage.list(child.id, { kind: "remote_task_terminal" })).toMatchObject([
+            { status: "consumed" },
+          ])
+          expect(CollabMessage.list(parent.id, { kind: "child_done" })).toHaveLength(1)
+          expect(CollabAgentNode.load(parent.id).active_children).toBe(0)
+        } finally {
+          CollabRuntime.abort(child.id)
+          prompt.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("does not finalize while a remote terminal callback arrives", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const attached = await ExperimentAgent.attach(item.expId)
+        const child = CollabAgentNode.activate(attached.agentId!)
+        const original = Session.messages
+        let release!: () => void
+        let started!: () => void
+        const ready = new Promise<void>((resolve) => {
+          started = resolve
+        })
+        const gate = new Promise<void>((resolve) => {
+          release = resolve
+        })
+        let calls = 0
+        const messages = spyOn(Session, "messages").mockImplementation(
+          (async (input: { sessionID: string; limit?: number }) => {
+            calls++
+            if (calls === 1) {
+              started()
+              await gate
+            }
+            return original(input)
+          }) as unknown as typeof Session.messages,
+        )
+        const prompt = spyOn(SessionPrompt, "prompt").mockResolvedValue(undefined as never)
+        const run = CollabLoop.start(child.id)
+        try {
+          await ready
+          await CollabMessage.post({
+            recipientAgentId: child.id,
+            senderAgentId: null,
+            kind: "remote_task_terminal",
+            payload: {
+              taskId: crypto.randomUUID(),
+              expId: item.expId,
+              kind: "experiment_run",
+              title: "Train model",
+              status: "finished",
+              logPath: null,
+              errorMessage: null,
+            },
+          })
+          release()
+
+          await run
+          expect(prompt).toHaveBeenCalledTimes(1)
+          expect(CollabAgentNode.load(child.id).status).toBe("completed")
+          expect(CollabMessage.list(child.id, { kind: "remote_task_terminal" })).toMatchObject([
+            { status: "consumed" },
+          ])
+        } finally {
+          release()
+          CollabRuntime.abort(child.id)
+          messages.mockRestore()
+          prompt.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("repairs a failed Atom parent before resuming the same experiment agent", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const attached = await ExperimentAgent.attach(item.expId)
+        const child = CollabAgentNode.load(attached.agentId!)
+        const parent = CollabAgentNode.load(child.parent_agent_id!)
+        CollabAgentNode.transition(child.id, "failed", {
+          error: { code: "LOOP_CRASH", message: "ProviderModelNotFoundError" },
+        })
+        CollabAgentNode.transition(parent.id, "failed", {
+          error: { code: "CHILD_FAILED_FAIL_FAST", message: "child failed" },
+        })
+
+        const start = spyOn(CollabLoop, "start").mockResolvedValue()
+        try {
+          const resumed = await Collab.resume({ agentId: child.id, prompt: "continue" })
+          const repaired = CollabAgentNode.load(parent.id)
+          expect(resumed.session_id).toBe(item.exp!.id)
+          expect(resumed.status).toBe("running")
+          expect(CollabAgentNode.isActive(repaired.status)).toBe(true)
+          expect(repaired.spec.policy?.on_fail).toBe("continue")
+          expect(repaired.active_children).toBe(1)
+        } finally {
+          start.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("uses the Atom model when the experiment model is unavailable", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const get = spyOn(Provider, "getModel").mockImplementation(async (providerID, modelID) => {
+          if (providerID === "atom" && modelID === "current") return {} as never
+          throw new Provider.ModelNotFoundError({ providerID, modelID, suggestions: [] })
+        })
+        const fallback = spyOn(Provider, "defaultModel").mockRejectedValue(new Error("no default"))
+        const list = spyOn(Provider, "list").mockResolvedValue({} as never)
+        try {
+          expect(
+            await SessionPrompt.resolveModel({
+              sessionID: (await Session.create({ title: "model recovery" })).id,
+              agent: "experiment",
+              preferred: { providerID: "removed", modelID: "old" },
+              fallback: { providerID: "atom", modelID: "current" },
+            }),
+          ).toEqual({ providerID: "atom", modelID: "current" })
+        } finally {
+          get.mockRestore()
+          fallback.mockRestore()
+          list.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("persists the recovered Atom model on the experiment agent", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const attached = await ExperimentAgent.attach(item.expId)
+        const child = CollabAgentNode.load(attached.agentId!)
+        CollabAgentNode.spec(child.id, {
+          ...child.spec,
+          model: { providerID: "removed", modelID: "old" },
+        })
+        const resolve = spyOn(SessionPrompt, "resolveModel").mockResolvedValue({
+          providerID: "atom",
+          modelID: "current",
+        })
+        const prompt = spyOn(SessionPrompt, "prompt").mockResolvedValue(undefined as never)
+        try {
+          await Collab.resume({
+            agentId: child.id,
+            prompt: "continue",
+            model: { providerID: "atom", modelID: "current" },
+          })
+          await CollabRuntime.get(child.id)?.promise
+          expect(CollabAgentNode.load(child.id).spec.model).toEqual({
+            providerID: "atom",
+            modelID: "current",
+          })
+          expect(prompt.mock.calls[0]?.[0]?.model).toEqual({ providerID: "atom", modelID: "current" })
+        } finally {
+          resolve.mockRestore()
+          prompt.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("keeps an experiment recoverable when its model disappears during a turn", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const attached = await ExperimentAgent.attach(item.expId)
+        const child = CollabAgentNode.activate(attached.agentId!)
+        CollabMessage.post({
+          recipientAgentId: child.id,
+          senderAgentId: null,
+          kind: "user_input",
+          payload: { text: "continue" },
+        })
+        const prompt = spyOn(SessionPrompt, "prompt").mockRejectedValue(
+          new Provider.ModelNotFoundError({ providerID: "removed", modelID: "old", suggestions: [] }),
+        )
+        try {
+          await CollabLoop.start(child.id)
+          const waiting = CollabAgentNode.load(child.id)
+          expect(waiting.status).toBe("waiting_interaction")
+          expect(waiting.session_id).toBe(item.exp!.id)
+          expect(CollabMessage.list(waiting.parent_agent_id!, { kind: "child_waiting" })).toHaveLength(1)
+          expect(CollabMessage.list(waiting.parent_agent_id!, { kind: "child_failed" })).toHaveLength(0)
+        } finally {
+          prompt.mockRestore()
+        }
+      },
+    })
+  })
+
+  test("creates a missing experiment session before attachment", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed({ session: false })
+        const [result, duplicate] = await Promise.all([
+          ExperimentAgent.attach(item.expId),
+          ExperimentAgent.attach(item.expId),
+        ])
+        const node = CollabAgentNode.load(result.agentId!)
+        const exp = Database.use((db) =>
+          db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_id, item.expId)).get(),
+        )
+        expect(result.status).toBe("attached")
+        expect(duplicate.agentId).toBe(result.agentId)
+        expect(exp?.exp_session_id).toBe(node.session_id)
+        expect(node.status).toBe("idle")
+      },
+    })
+  })
+
+  test("moves an idle experiment when its atom session changes", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const first = await ExperimentAgent.attach(item.expId)
+        const previous = CollabAgentNode.load(first.agentId!)
+        const session = await Session.create({ title: "Atom: replacement" })
+        Database.use((db) =>
+          db.update(AtomTable).set({ session_id: session.id }).where(eq(AtomTable.atom_id, item.atomId)).run(),
+        )
+
+        const result = await ExperimentAgent.attach(item.expId)
+        const moved = CollabAgentNode.load(result.agentId!)
+        const parent = CollabAgentNode.load(moved.parent_agent_id!)
+        expect(result.agentId).toBe(first.agentId)
+        expect(moved.parent_agent_id).not.toBe(previous.parent_agent_id)
+        expect(parent.session_id).toBe(session.id)
+        expect(moved.root_agent_id).toBe(parent.root_agent_id)
+      },
+    })
+  })
+
+  test("recovers the same agent and history when an experiment session is archived", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const first = await ExperimentAgent.attach(item.expId)
+        await Session.setArchived({ sessionID: item.exp!.id, time: Date.now() })
+
+        const result = await ExperimentAgent.attach(item.expId)
+        const node = CollabAgentNode.load(result.agentId!)
+        const exp = Database.use((db) =>
+          db.select().from(ExperimentTable).where(eq(ExperimentTable.exp_id, item.expId)).get(),
+        )
+        expect(result.agentId).toBe(first.agentId)
+        expect(node.session_id).toBe(exp!.exp_session_id!)
+        expect(node.session_id).toBe(item.exp!.id)
+        expect((await Session.get(node.session_id)).time.archived).toBeUndefined()
+        expect(node.status).toBe("idle")
+      },
+    })
+  })
+
+  test("retries a deferred atom move after the active runtime exits", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const first = await ExperimentAgent.attach(item.expId)
+        const node = CollabAgentNode.load(first.agentId!)
+        const previous = node.parent_agent_id!
+        CollabAgentNode.activate(node.id)
+        const session = await Session.create({ title: "Atom: replacement" })
+        Database.use((db) =>
+          db.update(AtomTable).set({ session_id: session.id }).where(eq(AtomTable.atom_id, item.atomId)).run(),
+        )
+
+        let finish!: () => void
+        const promise = new Promise<void>((resolve) => (finish = resolve))
+        CollabRuntime.register(node.id, new AbortController(), promise)
+        expect((await ExperimentAgent.attach(item.expId)).status).toBe("deferred")
+
+        CollabAgentNode.transition(node.id, "completed")
+        await CollabMessage.post({
+          recipientAgentId: previous,
+          senderAgentId: node.id,
+          kind: "child_done",
+          payload: { childAgentId: node.id, childName: node.name, summary: "done" },
+        })
+        finish()
+        await promise
+        await Bun.sleep(20)
+
+        const moved = CollabAgentNode.load(node.id)
+        expect(moved.parent_agent_id).not.toBe(previous)
+        expect(CollabAgentNode.load(moved.parent_agent_id!).session_id).toBe(session.id)
+      },
+    })
+  })
+
+  test("adopts a settled experiment root and preserves its descendants", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const root = Identifier.ascending("collab_agent")
+        CollabAgentNode.create({
+          id: root,
+          sessionId: item.exp!.id,
+          name: "legacy root",
+          projectId: Instance.project.id,
+          rootAgentId: root,
+          subagentType: "experiment",
+          spec: { initialPrompt: "" },
+        })
+        const session = await Session.create({ title: "legacy child" })
+        const child = CollabAgentNode.create({
+          id: Identifier.ascending("collab_agent"),
+          sessionId: session.id,
+          parentAgentId: root,
+          name: "legacy child",
+          projectId: Instance.project.id,
+          rootAgentId: root,
+          subagentType: "general",
+          spec: { initialPrompt: "" },
+          status: "completed",
+        })
+
+        const result = await ExperimentAgent.attach(item.expId)
+        const adopted = CollabAgentNode.load(root)
+        const parent = CollabAgentNode.load(adopted.parent_agent_id!)
+        expect(result).toEqual({ status: "attached", agentId: root })
+        expect(adopted.status).toBe("idle")
+        expect(adopted.root_agent_id).toBe(parent.root_agent_id)
+        expect(CollabAgentNode.load(child.id).parent_agent_id).toBe(root)
+        expect(CollabAgentNode.load(child.id).root_agent_id).toBe(parent.root_agent_id)
+        expect(parent.active_children).toBe(0)
+      },
+    })
+  })
+
+  test("defers adoption while a legacy descendant is active", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const root = Identifier.ascending("collab_agent")
+        CollabAgentNode.create({
+          id: root,
+          sessionId: item.exp!.id,
+          name: "legacy root",
+          projectId: Instance.project.id,
+          rootAgentId: root,
+          subagentType: "experiment",
+          spec: { initialPrompt: "" },
+        })
+        const session = await Session.create({ title: "active child" })
+        CollabAgentNode.create({
+          id: Identifier.ascending("collab_agent"),
+          sessionId: session.id,
+          parentAgentId: root,
+          name: "active child",
+          projectId: Instance.project.id,
+          rootAgentId: root,
+          subagentType: "general",
+          spec: { initialPrompt: "" },
+        })
+
+        const result = await ExperimentAgent.attach(item.expId)
+        expect(result.status).toBe("deferred")
+        expect(CollabAgentNode.load(root).parent_agent_id).toBeNull()
+      },
+    })
+  })
+
+  test("resume activates an idle experiment and blocks human input", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const result = await ExperimentAgent.attach(item.expId)
+        const start = spyOn(CollabLoop, "start").mockResolvedValue()
+        const release = ExperimentAgent.claimHuman(item.exp!.id)
+        await expect(Collab.resume({ agentId: result.agentId!, prompt: "race with human" })).rejects.toBeInstanceOf(
+          Session.BusyError,
+        )
+        release()
+        expect(CollabAgentNode.load(result.agentId!).status).toBe("idle")
+        await Collab.resume({ agentId: result.agentId!, prompt: "run this experiment" })
+
+        const child = CollabAgentNode.load(result.agentId!)
+        const parent = CollabAgentNode.load(child.parent_agent_id!)
+        expect(child.status).toBe("running")
+        expect(parent.active_children).toBe(1)
+        expect(() => ExperimentAgent.assertHuman(item.exp!.id)).toThrow(ExperimentAgent.BusyError)
+        start.mockRestore()
+      },
+    })
+  })
+
+  test("removing an experiment session removes spawned descendants", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const result = await ExperimentAgent.attach(item.expId)
+        const peer = await Collab.createSubSession({ title: "spawned peer" })
+        const child = CollabAgentNode.create({
+          id: Identifier.ascending("collab_agent"),
+          sessionId: peer.id,
+          parentAgentId: result.agentId,
+          name: "spawned peer",
+          projectId: Instance.project.id,
+          rootAgentId: CollabAgentNode.load(result.agentId!).root_agent_id,
+          subagentType: "general",
+          spec: { initialPrompt: "" },
+          status: "completed",
+        })
+
+        await Session.remove(item.exp!.id)
+        expect(CollabAgentNode.tryLoad(result.agentId!)).toBeUndefined()
+        expect(CollabAgentNode.tryLoad(child.id)).toBeUndefined()
+        await expect(Session.get(peer.id)).rejects.toBeDefined()
+      },
+    })
+  })
+
+  test("removing an active experiment reports failure to its atom", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const result = await ExperimentAgent.attach(item.expId)
+        const active = CollabAgentNode.activate(result.agentId!)
+        const parent = active.parent_agent_id!
+
+        await Session.remove(item.exp!.id)
+        expect(CollabAgentNode.load(parent).active_children).toBe(0)
+        const messages = CollabMessage.list(parent, { kind: "child_failed" })
+        expect(messages).toHaveLength(1)
+        expect((messages[0].payload_json as { childAgentId: string }).childAgentId).toBe(active.id)
+      },
+    })
+  })
+
+  test("removing an atom session detaches but preserves experiment sessions", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const item = await seed()
+        const result = await ExperimentAgent.attach(item.expId)
+        await Session.remove(item.atom.id)
+
+        const node = CollabAgentNode.load(result.agentId!)
+        expect(node.parent_agent_id).toBeNull()
+        expect(node.root_agent_id).toBe(node.id)
+        expect((await Session.get(item.exp!.id)).id).toBe(item.exp!.id)
+      },
+    })
+  })
+})

--- a/packages/opencode/test/session/experiment-workspace.test.ts
+++ b/packages/opencode/test/session/experiment-workspace.test.ts
@@ -18,6 +18,7 @@ describe("session.experiment-workspace", () => {
         const root = Identifier.descending("session")
         const child = Identifier.descending("session")
         const peer = Identifier.descending("session")
+        const nested = Identifier.descending("session")
         const research = crypto.randomUUID()
         const exp = crypto.randomUUID()
         const code = path.join(tmp.path, ".openresearch_worktrees", exp)
@@ -54,6 +55,17 @@ describe("session.experiment-workspace", () => {
                 slug: "peer",
                 directory: tmp.path,
                 title: "peer",
+                version: "test",
+                time_created: now,
+                time_updated: now,
+              },
+              {
+                id: nested,
+                project_id: Instance.project.id,
+                parent_id: peer,
+                slug: "nested-task",
+                directory: tmp.path,
+                title: "nested task",
                 version: "test",
                 time_created: now,
                 time_updated: now,
@@ -107,6 +119,7 @@ describe("session.experiment-workspace", () => {
         expect(ExperimentWorkspace.prompt(root)).toBe(expected)
         expect(ExperimentWorkspace.prompt(child)).toBe(expected)
         expect(ExperimentWorkspace.prompt(peer)).toBe(expected)
+        expect(ExperimentWorkspace.prompt(nested)).toBe(expected)
         expect(expected.split("\n")).toHaveLength(1)
       },
     })

--- a/packages/opencode/test/tool/experiment-remote-task-lifecycle.test.ts
+++ b/packages/opencode/test/tool/experiment-remote-task-lifecycle.test.ts
@@ -625,7 +625,9 @@ describe("tool.experiment-remote-task lifecycle", () => {
             context,
           )
           expect(again.metadata.duplicate).toBe(true)
-          expect(Database.use((db) => db.select().from(RemoteTaskListenerTable).all())).toHaveLength(1)
+          const listeners = Database.use((db) => db.select().from(RemoteTaskListenerTable).all())
+          expect(listeners).toHaveLength(1)
+          expect(listeners[0].mode).toBe("collab")
           expect(Collab.workflowAsyncState(session.id).hasRemoteTaskListeners).toBe(true)
 
           ExperimentRemoteTask.update({ taskId: started.metadata.taskId, status: "finished", errorMessage: null })
@@ -647,6 +649,55 @@ describe("tool.experiment-remote-task lifecycle", () => {
 
           ExperimentRemoteTask.update({ taskId: started.metadata.taskId, status: "finished" })
           expect(CollabMessage.list(node.id, { kind: "remote_task_terminal" })).toHaveLength(1)
+        } finally {
+          CollabAutoWake.setEnabled(true)
+        }
+      },
+    })
+  })
+
+  test("registers human session listeners in direct mode", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const { Session } = await import("../../src/session")
+        const { Collab, CollabAutoWake } = await import("../../src/collab")
+        const { ExperimentRemoteTaskGetTool, ExperimentRemoteTaskStartTool } = await import(
+          "../../src/tool/experiment-remote-task"
+        )
+        const { SessionOwnership } = await import("../../src/session/ownership")
+        CollabAutoWake.setEnabled(false)
+        try {
+          await seed(tmp.path)
+          const session = await Session.create({ title: "human remote listener" })
+          const context = { ...ctx, sessionID: session.id }
+          const start = await ExperimentRemoteTaskStartTool.init()
+          const started = await start.execute(
+            {
+              expId: "exp-1",
+              kind: "experiment_run",
+              title: "Train model",
+              remoteRoot: "/mnt/zhouzih",
+              command: "python train.py",
+              targetPath: null,
+            },
+            context,
+          )
+          const release = SessionOwnership.claim(session.id, "human")!
+          try {
+            const get = await ExperimentRemoteTaskGetTool.init()
+            await get.execute(
+              { expId: "exp-1", taskId: started.metadata.taskId, listenForTerminal: true },
+              context,
+            )
+          } finally {
+            release()
+          }
+
+          const listener = Database.use((db) => db.select().from(RemoteTaskListenerTable).get())
+          expect(listener?.mode).toBe("direct")
+          expect(Collab.workflowAsyncState(session.id).hasRemoteTaskListeners).toBe(false)
         } finally {
           CollabAutoWake.setEnabled(true)
         }

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -4496,9 +4496,9 @@ export class Active extends HeyApiClient {
 
 export class PeerSessions extends HeyApiClient {
   /**
-   * List session ids of all Collab peer agents (non-root) in current project
+   * List session ids of spawned Collab peer agents in current project
    *
-   * Returns the set of session ids that belong to peer (non-root) Collab agents. Used by the UI sidebar to hide peer sessions from the flat session list — they are only ever reached via the parent agent's dock.
+   * Returns session ids explicitly marked as spawned Collab peers. Domain-owned Atom and Experiment sessions remain visible in the research tree.
    */
   public list<ThrowOnError extends boolean = false>(
     parameters?: {
@@ -4609,6 +4609,7 @@ export class Agent extends HeyApiClient {
         | "child_waiting"
         | "child_progress"
         | "remote_task_terminal"
+        | "session_remote_task_terminal"
         | "cancel"
         | "user_input"
         | "system"

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -764,7 +764,15 @@ export type CollabAgent = {
   project_id: string
   root_agent_id: string
   subagent_type: string
-  status: "pending" | "running" | "blocked_on_children" | "waiting_interaction" | "completed" | "failed" | "canceled"
+  status:
+    | "idle"
+    | "pending"
+    | "running"
+    | "blocked_on_children"
+    | "waiting_interaction"
+    | "completed"
+    | "failed"
+    | "canceled"
   phase: "main_loop" | "awaiting_children" | "draining"
   spec: CollabAgentSpec
   result: CollabAgentResult | null
@@ -789,7 +797,15 @@ export type EventCollabAgentStatus = {
   properties: {
     agentId: string
     rootAgentId: string
-    status: "pending" | "running" | "blocked_on_children" | "waiting_interaction" | "completed" | "failed" | "canceled"
+    status:
+      | "idle"
+      | "pending"
+      | "running"
+      | "blocked_on_children"
+      | "waiting_interaction"
+      | "completed"
+      | "failed"
+      | "canceled"
     phase: "main_loop" | "awaiting_children" | "draining"
     active_children: number
   }
@@ -826,6 +842,7 @@ export type EventCollabMessagePosted = {
       | "child_waiting"
       | "child_progress"
       | "remote_task_terminal"
+      | "session_remote_task_terminal"
       | "cancel"
       | "user_input"
       | "system"
@@ -843,6 +860,7 @@ export type EventCollabMessageConsumed = {
       | "child_waiting"
       | "child_progress"
       | "remote_task_terminal"
+      | "session_remote_task_terminal"
       | "cancel"
       | "user_input"
       | "system"
@@ -2077,6 +2095,7 @@ export type CollabMessage = {
     | "child_waiting"
     | "child_progress"
     | "remote_task_terminal"
+    | "session_remote_task_terminal"
     | "cancel"
     | "user_input"
     | "system"
@@ -6560,6 +6579,7 @@ export type CollabAgentMessagesData = {
       | "child_waiting"
       | "child_progress"
       | "remote_task_terminal"
+      | "session_remote_task_terminal"
       | "cancel"
       | "user_input"
       | "system"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -11435,8 +11435,8 @@
             }
           }
         ],
-        "summary": "List session ids of all Collab peer agents (non-root) in current project",
-        "description": "Returns the set of session ids that belong to peer (non-root) Collab agents. Used by the UI sidebar to hide peer sessions from the flat session list — they are only ever reached via the parent agent's dock.",
+        "summary": "List session ids of spawned Collab peer agents in current project",
+        "description": "Returns session ids explicitly marked as spawned Collab peers. Domain-owned Atom and Experiment sessions remain visible in the research tree.",
         "responses": {
           "200": {
             "description": "Peer session ids",
@@ -18062,6 +18062,7 @@
           "status": {
             "type": "string",
             "enum": [
+              "idle",
               "pending",
               "running",
               "blocked_on_children",
@@ -18203,6 +18204,7 @@
               "status": {
                 "type": "string",
                 "enum": [
+                  "idle",
                   "pending",
                   "running",
                   "blocked_on_children",


### PR DESCRIPTION
- Attach experiments as durable idle children of their canonical Atom agents.
- Let Atoms resume the same experiment sessions while preserving IDs and history.
- Repair archived, failed, moved, and legacy Atom-Experiment relationships.
- Coordinate human and Collab ownership to prevent concurrent session turns.
- Route remote-task completion to human sessions or Atom-controlled Collab loops.
- Recover unavailable models and keep experiment agents in resumable waiting states.
- Harden cross-directory wake-up, finalization, workspace inheritance, and session cleanup.
- Expose new lifecycle states in the UI and route session events to the correct store.
- Add the listener-mode migration, regenerate SDK types, and expand lifecycle coverage.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
